### PR TITLE
Implement Cantor set iteration with flexible inputs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,8 @@ module.exports = {
         'arrow-spacing': [
             'error', { 'before': true, 'after': true }
         ],
-        'no-unused-vars': ["warn"],
-        'no-useless-catch': 0
+        'no-unused-vars': ['warn'],
+        'no-useless-catch': 0,
+        'no-debugger': ['warn']
     }
 }

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ https://github.com/bambery/cantor_3-4 to demonstrate asymmetrical Cantor sets.
 ## Usage Permisions
 When this repository is complete, I will attach a usage license that allows for general, non-commercial use and modification, with accrediation back to me.
 
-This repository is provided for free to those who wish to play around with Cantor-like sets with flexible constraints. The code is written to be generally comprehensible to those with basic coding and mathmatical skills, and can be extended to cover additional scenarios if desired. If modifying the code, I highly recommend rewriting tests to keep them up-to-date: tiny errors quickly spiral to spoil all results.
+This repository is provided for free to those who wish to play around with Cantor-like sets with flexible constraints. The code is written to avoid recursion and be generally comprehensible to those with basic coding and mathmatical skills, and can be extended to cover additional scenarios if desired. If modifying the code, I highly recommend rewriting tests to keep them up-to-date: tiny errors quickly spiral to spoil all results.
 
 ## How to Use
 Using the UI, select the number of segments to divide the interval into. Next, select the segments you wish to have removed with each iteration. Third, select how many iterations you wish to view, keeping in mind that the more iterations, the less comprehensible the graphics will be.
 
 ## Downloading the generated Cantor sets
-After pressing "Cantorify!", you will see a graphic representing the intervals for each Cantorian iteration with a table listing the endpoints. All tables can be downloaded into a csv with the "download this data" button at the top.
+After pressing "Cantorify!", you will see a graphic representing the intervals for each Cantorian iteration with a table listing the endpoints. All tables can be downloaded into a csv with the "Download This Data" button at the top.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@
 
 This is a react rewrite of a small proof of concept that I hacked together:
 https://github.com/bambery/cantor_3-4 to demonstrate asymmetrical Cantor sets.
+
+## Usage Permisions
+When this repository is complete, I will attach a usage license that allows for general, non-commercial use and modification, with accrediation back to me.
+
+This repository is provided for free to those who wish to play around with Cantor-like sets with flexible constraints. The code is written to be generally comprehensible to those with basic coding and mathmatical skills, and can be extended to cover additional scenarios if desired. If modifying the code, I highly recommend rewriting tests to keep them up-to-date: tiny errors quickly spiral to spoil all results.
+
+## How to Use
+Using the UI, select the number of segments to divide the interval into. Next, select the segments you wish to have removed with each iteration. Third, select how many iterations you wish to view, keeping in mind that the more iterations, the less comprehensible the graphics will be.
+
+## Downloading the generated Cantor sets
+After pressing "Cantorify!", you will see a graphic representing the intervals for each Cantorian iteration with a table listing the endpoints. All tables can be downloaded into a csv with the "download this data" button at the top.

--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,9 @@ function App() {
 
     debugger
 
+    // numberline
+    // summary
+    // intervalChart
     return (
         <div>
             whast up

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,9 @@
 import Fraction from './models/fraction'
 import Interval from './models/interval'
 import IntervalCollection from './models/interval_collection'
+import { type } from './shared/utils'
 
-import { cantor } from './shared/cantor'
+import Cantor from './shared/cantor'
 
 //import logo from './logo.svg';
 import './App.css'
@@ -25,14 +26,15 @@ function App() {
     let aaR = new Fraction(5,5)
 
     let inta = new Interval(aaL, aaR)
-    window.cantor = cantor
+    window.Cantor = Cantor
     window.Fraction = Fraction
     window.Interval = Interval
     window.IntervalCollection = IntervalCollection
+    window.mytype = type
 
     let hh = new Interval(new Fraction(2, 5), new Fraction(3, 5))
 
-    let res = cantor(5, [2, 3], 2)
+    let res = new Cantor(5, [2, 4], 2)
 
     debugger
 

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import Fraction from './models/fraction'
 import Interval from './models/interval'
 import IntervalCollection from './models/interval_collection'
 
-import { removeIntervals as cantor } from './shared/cantor'
+import { cantor } from './shared/cantor'
 
 //import logo from './logo.svg';
 import './App.css'
@@ -28,11 +28,11 @@ function App() {
     window.cantor = cantor
     window.Fraction = Fraction
     window.Interval = Interval
+    window.IntervalCollection = IntervalCollection
 
-    debugger
     let hh = new Interval(new Fraction(2, 5), new Fraction(3, 5))
 
-    let res = cantor(hh, 5, [2, 4])
+    let res = cantor(3, [2], 3)
 
     debugger
 

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import Interval from './models/interval'
 import IntervalCollection from './models/interval_collection'
 import { type } from './shared/utils'
 
-import Cantor from './shared/cantor'
+import Cantor from './models/cantor'
 
 //import logo from './logo.svg';
 import './App.css'

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,8 @@ import Fraction from './models/fraction'
 import Interval from './models/interval'
 import IntervalCollection from './models/interval_collection'
 
+import { removeIntervals as cantor } from './shared/cantor'
+
 //import logo from './logo.svg';
 import './App.css'
 
@@ -19,17 +21,18 @@ function App() {
 
     let sc1 = new IntervalCollection([ls1, ls2])
 
-    let baz = new Fraction(0, 10)
-    let bazR = new Fraction(2, 10)
-    let moo = new Fraction(7, 10)
-    let mooR = new Fraction(10, 10)
+    let aaL = new Fraction(0,5)
+    let aaR = new Fraction(5,5)
 
-    let ls3 = new Interval(baz, bazR)
-    let ls4 = new Interval(moo, mooR)
-
-    let sc2 = new IntervalCollection([ls3, ls4])
-
+    let inta = new Interval(aaL, aaR)
+    window.cantor = cantor
     window.Fraction = Fraction
+    window.Interval = Interval
+
+    debugger
+    let hh = new Interval(new Fraction(2, 5), new Fraction(3, 5))
+
+    let res = cantor(hh, 5, [2, 4])
 
     debugger
 

--- a/src/App.js
+++ b/src/App.js
@@ -32,7 +32,7 @@ function App() {
 
     let hh = new Interval(new Fraction(2, 5), new Fraction(3, 5))
 
-    let res = cantor(3, [2], 3)
+    let res = cantor(5, [2, 3], 2)
 
     debugger
 

--- a/src/models/cantor.js
+++ b/src/models/cantor.js
@@ -1,6 +1,6 @@
-import Fraction from '../models/fraction'
-import Interval from '../models/interval'
-import IntervalCollection from '../models/interval_collection'
+import Fraction from './fraction'
+import Interval from './interval'
+import IntervalCollection from './interval_collection'
 import { ValueError } from './errors'
 
 // in case I ever decide to look into alternating the segments between iterations, I removed most of the utility functions from the class to keep the flexibility that was lost when everything was tied to an instance
@@ -53,15 +53,11 @@ function removeIntervals(interval, numSegments, toRemove){
         ? new Fraction(1, numSegments)
         : new Fraction(commonInt.len.num, commonInt.len.den * numSegments)
 
-    //let toRemoveInt = toRemove.map( seg => new Interval(new Fraction(commonInt.left.num + seg - 1, cDen), new Fraction(commonInt.left.num + seg, cDen)) )
     let toRemoveInt = convertSegmentsToIntervals(commonInt, segmentLength, toRemove)
     let result = [commonInt]
 
     while(toRemoveInt.length > 0){
         let curr = result.pop()
-        if(curr === undefined){
-            throw new Error('u messed up')
-        }
         let seg = toRemoveInt.shift()
         result = result.concat(curr.subtract(seg))
     }
@@ -70,7 +66,8 @@ function removeIntervals(interval, numSegments, toRemove){
 }
 
 
-// returns the array of intervals to remove
+// Given a list of the 1-based index of the segments to remove and the Interval to remove them from, returns an array of Intervals to remove.
+// Will combine sequential segments into one large segment
 function convertSegmentsToIntervals(interval, segmentLength, segNum){
     let curr = []
     let intervals = []
@@ -85,12 +82,10 @@ function convertSegmentsToIntervals(interval, segmentLength, segNum){
                 interval.left.add(segmentLength.mult(curr.shift() - 1)),
                 interval.left.add(segmentLength.mult(segNum[i]))
             )
-           // let newInterval = new Interval( new Fraction(interval.left.num + ((curr.shift() - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num), segmentLength.den) )
             intervals.push(newInterval)
             curr = []
         } else {
             // current digit is not part of any sequential string
-           // let newInterval = new Interval( new Fraction(interval.left.num + ((segNum[i] - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num), segmentLength.den))
             let newInterval = new Interval(
                 interval.left.add(segmentLength.mult(segNum[i]-1)),
                 interval.left.add(segmentLength.mult(segNum[i]))

--- a/src/models/cantor.js
+++ b/src/models/cantor.js
@@ -1,7 +1,7 @@
 import Fraction from './fraction'
 import Interval from './interval'
 import IntervalCollection from './interval_collection'
-import { ValueError } from './errors'
+import { ValueError } from '../shared/errors'
 
 // in case I ever decide to look into alternating the segments between iterations, I removed most of the utility functions from the class to keep the flexibility that was lost when everything was tied to an instance
 

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -13,6 +13,7 @@ class Fraction {
         } else if (numerator < 0 || denominator < 0){
             throw new FracError.NoNegativeFractions()
         } else if (denominator < numerator){
+            debugger // eslint-disable-line
             throw new FracError.FractionTooLarge()
         } else if (typeof numerator !== 'undefined' && typeof denominator !== 'undefined') {
             if (type(numerator) === 'number' && type(denominator) === 'number'){
@@ -92,6 +93,11 @@ class Fraction {
     lessThan(rhs){
         let [fracA, fracB] = Fraction.commonDen(this, rhs)
         return (fracA.num < fracB.num)
+    }
+
+    greaterThan(rhs){
+        let [fracA, fracB] = Fraction.commonDen(this, rhs)
+        return (fracA.num > fracB.num)
     }
 
     equals(rhs){

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -1,26 +1,47 @@
-import { lcm, type } from '../shared/utils'
+import { lcm, type, checkArrContents } from '../shared/utils'
 import { FracError } from '../shared/errors'
 
 class Fraction {
     #numerator = 1
     #denominator = 1
 
-    constructor(numerator, denominator) {
-        if (![0, 2].includes(arguments.length)) {
-            throw new TypeError('Must pass two numbers to new Fraction')
-        } else if(denominator === 0){
+    constructor(numeratorArg, denominatorArg) {
+        let numerator, denominator
+
+        if(arguments.length === 0
+            ||(arguments.length === 1
+                && type(numeratorArg) === 'Array'
+                && numeratorArg.length === 0))
+        {
+            this.#numerator = 1
+            this.#denominator = 1
+            return this
+        } else if (arguments.length === 1
+            && type(numeratorArg) === 'Array'
+            && numeratorArg.length === 2
+            && checkArrContents(numeratorArg, 'number'))
+        {
+            numerator = numeratorArg[0]
+            denominator = numeratorArg[1]
+        } else if (arguments.length === 2
+            && type(numeratorArg) === 'number'
+            && type(denominatorArg === 'number'))
+        {
+            numerator = numeratorArg
+            denominator = denominatorArg
+        } else {
+            throw new TypeError(`Must send either an Array of two numbers, or two numbers to new Fraction: you passed ${numeratorArg}, ${denominatorArg}`)
+        }
+
+        if(denominator === 0){
             throw new FracError.ZeroDenominator()
         } else if (numerator < 0 || denominator < 0){
             throw new FracError.NoNegativeFractions()
         } else if (denominator < numerator){
             throw new FracError.FractionTooLarge()
-        } else if (type(numerator) !== 'undefined' && type(denominator) !== 'undefined') {
-            if (type(numerator) === 'number' && type(denominator) === 'number'){
-                this.#numerator = numerator
-                this.#denominator = denominator
-            } else {
-                throw new TypeError(`Must pass two numbers to new Fraction: you passed ${type(numerator)} and ${type(denominator)}`)
-            }
+        } else {
+            this.#numerator = numerator
+            this.#denominator = denominator
         }
         // stop moving this into a getter! Console debugging is easier this way
         this.str = `${this.#numerator}/${this.#denominator}`

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -24,7 +24,7 @@ class Fraction {
             }
         }
         // stop moving this into a getter! Console debugging is easier this way
-        this.str = `{Fraction: ${this.#numerator}/${this.#denominator}}`
+        this.str = `${this.#numerator}/${this.#denominator}`
     }
 
     // given 2 fractions, convert them to have a common denominator and return them in a 2 item Array

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -24,7 +24,7 @@ class Fraction {
             }
         }
         // stop moving this into a getter! Console debugging is easier this way
-        this.str = `${this.#numerator}/${this.#denominator}`
+        this.str = `{Fraction: ${this.#numerator}/${this.#denominator}}`
     }
 
     // given 2 fractions, convert them to have a common denominator and return them in a 2 item Array

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -13,7 +13,6 @@ class Fraction {
         } else if (numerator < 0 || denominator < 0){
             throw new FracError.NoNegativeFractions()
         } else if (denominator < numerator){
-            debugger // eslint-disable-line
             throw new FracError.FractionTooLarge()
         } else if (typeof numerator !== 'undefined' && typeof denominator !== 'undefined') {
             if (type(numerator) === 'number' && type(denominator) === 'number'){
@@ -78,16 +77,18 @@ class Fraction {
     }
 
     add(rhs) {
-        if (type(rhs) !== 'Fraction'){
+        if(type(rhs) === 'number'){
+            return new Fraction(this.num + rhs, this.den)
+        } else if(type(rhs) === 'Fraction'){
+            let [ leftHS, rightHS ] = Fraction.commonDen(this, rhs)
+            let numerator = leftHS.num + rightHS.num
+            if (numerator > leftHS.den){
+                throw new FracError.FractionTooLarge(`Sum of ${this.str} and ${rhs.str} would be greater than 1.`)
+            }
+            return new Fraction(numerator, leftHS.den)
+        } else {
             throw new TypeError(`Must pass only Fraction argument to add: you passed in ${type(rhs)}`)
         }
-
-        let [ leftHS, rightHS ] = Fraction.commonDen(this, rhs)
-        let numerator = leftHS.num + rightHS.num
-        if (numerator > leftHS.den){
-            throw new FracError.FractionTooLarge(`Sum of ${this.str} and ${rhs.str} would be greater than 1.`)
-        }
-        return new Fraction(numerator, leftHS.den)
     }
 
     lessThan(rhs){
@@ -103,6 +104,16 @@ class Fraction {
     equals(rhs){
         let [fracA, fracB] = Fraction.commonDen(this, rhs)
         return (fracA.num === fracB.num)
+    }
+
+    mult(rhs){
+        if(type(rhs) === 'number'){
+            return new Fraction(this.num * rhs, this.den)
+        } else if (type(rhs) === 'Fraction'){
+            return new Fraction(this.num * rhs.num, this.den * rhs.den)
+        } else {
+            throw new TypeError('Can only multiply fractions by a scalar or another fraction.')
+        }
     }
 }
 

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -14,7 +14,7 @@ class Fraction {
             throw new FracError.NoNegativeFractions()
         } else if (denominator < numerator){
             throw new FracError.FractionTooLarge()
-        } else if (typeof numerator !== 'undefined' && typeof denominator !== 'undefined') {
+        } else if (type(numerator) !== 'undefined' && type(denominator) !== 'undefined') {
             if (type(numerator) === 'number' && type(denominator) === 'number'){
                 this.#numerator = numerator
                 this.#denominator = denominator

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -34,12 +34,13 @@ class Interval {
     }
 
     commonDen(desiredDen = null) {
+        var common = null
         if(!desiredDen){
-            var common = lcm([this.left.den, this.right.den])
+            common = lcm([this.left.den, this.right.den])
         } else if (desiredDen % this.left.den > 0 || desiredDen % this.right.den > 0){
             throw new ValueError(`Cannot convert ${this.str} to denominator ${desiredDen}.`)
         } else {
-            var common = desiredDen
+            common = desiredDen
         }
         let pointL = new Fraction(common/this.left.den * this.left.num, common)
         let pointR = new Fraction(common/this.right.den * this.right.num, common)
@@ -54,7 +55,7 @@ class Interval {
         let subCommon = intToSub.commonDen(commonDenominator)
 
         // check that the interval to be subtracted is contained in the current interval
-        if(!intCommon.right.lessThan(subCommon.left)){
+        if(!intCommon.left.lessThan(subCommon.left) || !intCommon.right.greaterThan(subCommon.right)){
             throw new IntervalRangeError(`Interval ${intToSub.str} is not contained within and cannot be subtracted from ${this.str}.`)
         }
 
@@ -68,7 +69,7 @@ class Interval {
         let commonDenominator = lcm([this.left.den, this.right.den, intToAdd.left.den, intToAdd.right.den])
         let intCommon = this.commonDen(commonDenominator)
         let addCommon = intToAdd.commonDen(commonDenominator)
-        if(intCommon.right.num + 1 !== subCommon.left.num){
+        if(intCommon.right.num + 1 !== addCommon.left.num){
             throw new IntervalRangeError(`The given interval, ${intToAdd.str}, is not sequrntial to this interval, ${this.str}.`)
         }
 

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -1,5 +1,6 @@
-import { type } from '../shared/utils'
-import { IntervalRangeError } from '../shared/errors'
+import { type, lcm } from '../shared/utils'
+import { IntervalRangeError, ValueError } from '../shared/errors'
+import Fraction from './fraction'
 
 class Interval {
     #leftEndpoint = null
@@ -9,7 +10,7 @@ class Interval {
         if (type(leftEndpointArg) !== 'Fraction' || type(rightEndpointArg) !== 'Fraction') {
             throw new TypeError('Interval constructor requires two fractions.')
         } else if (rightEndpointArg.lessThan(leftEndpointArg)) {
-            throw new IntervalRangeError('Left endpoint must be smaller than right endpoint.')
+            throw new IntervalRangeError(`Left endpoint ${leftEndpointArg.str} must be smaller than right endpoint ${rightEndpointArg.str}.`)
         } else if (leftEndpointArg.equals(rightEndpointArg)) {
             throw new IntervalRangeError('Interval must have length greater than 0.')
         }
@@ -30,6 +31,48 @@ class Interval {
 
     get right() {
         return this.#rightEndpoint
+    }
+
+    commonDen(desiredDen = null) {
+        if(!desiredDen){
+            var common = lcm([this.left.den, this.right.den])
+        } else if (desiredDen % this.left.den > 0 || desiredDen % this.right.den > 0){
+            throw new ValueError(`Cannot convert ${this.str} to denominator ${desiredDen}.`)
+        } else {
+            var common = desiredDen
+        }
+        let pointL = new Fraction(common/this.left.den * this.left.num, common)
+        let pointR = new Fraction(common/this.right.den * this.right.num, common)
+        return new Interval(pointL, pointR)
+    }
+
+    // removes an internal part of the interval, returns a 2 element array of the remaining line segments
+    subtract(intToSub) {
+        let remainingSegments = []
+        let commonDenominator = lcm([this.left.den, this.right.den, intToSub.left.den, intToSub.right.den])
+        let intCommon = this.commonDen(commonDenominator)
+        let subCommon = intToSub.commonDen(commonDenominator)
+
+        // check that the interval to be subtracted is contained in the current interval
+        if(!intCommon.right.lessThan(subCommon.left)){
+            throw new IntervalRangeError(`Interval ${intToSub.str} is not contained within and cannot be subtracted from ${this.str}.`)
+        }
+
+        remainingSegments.push( new Interval(intCommon.left, subCommon.left) )
+        remainingSegments.push( new Interval(subCommon.right, intCommon.right) )
+        return remainingSegments
+    }
+
+    // returns a new interval representing the sum of the two sequential intervals
+    add(intToAdd) {
+        let commonDenominator = lcm([this.left.den, this.right.den, intToAdd.left.den, intToAdd.right.den])
+        let intCommon = this.commonDen(commonDenominator)
+        let addCommon = intToAdd.commonDen(commonDenominator)
+        if(intCommon.right.num + 1 !== subCommon.left.num){
+            throw new IntervalRangeError(`The given interval, ${intToAdd.str}, is not sequrntial to this interval, ${this.str}.`)
+        }
+
+        return new Interval(intCommon.left, addCommon.right)
     }
 }
 

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -1,4 +1,4 @@
-import { type, lcm } from '../shared/utils'
+import { type, lcm, checkArrContents } from '../shared/utils'
 import { IntervalRangeError, ValueError } from '../shared/errors'
 import Fraction from './fraction'
 
@@ -7,18 +7,35 @@ class Interval {
     #rightEndpoint = null
 
     constructor ( leftEndpointArg, rightEndpointArg ){
-        if (type(leftEndpointArg) !== 'Fraction' || type(rightEndpointArg) !== 'Fraction') {
-            throw new TypeError('Interval constructor requires two fractions.')
-        } else if (rightEndpointArg.lessThan(leftEndpointArg)) {
-            throw new IntervalRangeError(`Left endpoint ${leftEndpointArg.str} must be smaller than right endpoint ${rightEndpointArg.str}.`)
-        } else if (leftEndpointArg.equals(rightEndpointArg)) {
+        let tempLeft, tempRight
+        if(arguments.length === 1
+            && type(leftEndpointArg) === 'Array'
+            && leftEndpointArg.length === 2
+            && (leftEndpointArg[0].length === 2 && leftEndpointArg[1].length === 2)
+            && (type(leftEndpointArg[0]) === 'Array' && type(leftEndpointArg[1]) === 'Array')
+            && (checkArrContents(leftEndpointArg[0], 'number') && checkArrContents(leftEndpointArg[1], 'number'))
+        ){
+            tempLeft = new Fraction(leftEndpointArg[0])
+            tempRight = new Fraction(leftEndpointArg[1])
+        } else if (arguments.length === 2
+            && type(leftEndpointArg) === 'Fraction' && type(rightEndpointArg) === 'Fraction') {
+            tempLeft = leftEndpointArg
+            tempRight = rightEndpointArg
+        } else {
+            throw new TypeError(`Interval constructor requires 1) two fractions or 2) an array containing two sub-arrays representing the two Fractions: you passed ${leftEndpointArg}, ${rightEndpointArg}`)
+        }
+
+        if (tempRight.lessThan(tempLeft)) {
+            throw new IntervalRangeError(`Left endpoint ${tempLeft.str} must be smaller than right endpoint ${tempRight.str}.`)
+        } else if (tempLeft.equals(tempRight)) {
             throw new IntervalRangeError('Interval must have length greater than 0.')
         }
 
-        this.#leftEndpoint = leftEndpointArg
-        this.#rightEndpoint = rightEndpointArg
+        this.#leftEndpoint = tempLeft
+        this.#rightEndpoint = tempRight
         // do not move into getter - makes console debugging easier
         this.str = `{Interval: [${this.#leftEndpoint.reduce().str}, ${this.#rightEndpoint.reduce().str}], Length: ${this.len.reduce().str}}`
+        this.strMinimal = `[${this.#leftEndpoint.reduce().str}, ${this.#rightEndpoint.reduce().str}]`
     }
 
     get len() {

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -18,7 +18,7 @@ class Interval {
         this.#leftEndpoint = leftEndpointArg
         this.#rightEndpoint = rightEndpointArg
         // do not move into getter - makes console debugging easier
-        this.str = `{Interval: [${this.#leftEndpoint.str}, ${this.#rightEndpoint.str}], Length: ${this.len.reduce().str}}`
+        this.str = `{Interval: [${this.#leftEndpoint.reduce().str}, ${this.#rightEndpoint.reduce().str}], Length: ${this.len.reduce().str}}`
     }
 
     get len() {

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -18,7 +18,7 @@ class Interval {
         this.#leftEndpoint = leftEndpointArg
         this.#rightEndpoint = rightEndpointArg
         // do not move into getter - makes console debugging easier
-        this.str = `Left: ${this.#leftEndpoint.str}, Right: ${this.#rightEndpoint.str}, Length: ${this.len.reduce().str}`
+        this.str = `{Interval: Left: ${this.#leftEndpoint.str}, Right: ${this.#rightEndpoint.str}, Length: ${this.len.reduce().str}}`
     }
 
     get len() {
@@ -76,5 +76,8 @@ class Interval {
         return new Interval(intCommon.left, addCommon.right)
     }
 }
+
+Interval.unit = new Interval( new Fraction(0, 1), new Fraction(1, 1) )
+Interval.prototype.toString = function intervalToString() { return this.str }
 
 export default Interval

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -18,7 +18,7 @@ class Interval {
         this.#leftEndpoint = leftEndpointArg
         this.#rightEndpoint = rightEndpointArg
         // do not move into getter - makes console debugging easier
-        this.str = `{Interval: Left: ${this.#leftEndpoint.str}, Right: ${this.#rightEndpoint.str}, Length: ${this.len.reduce().str}}`
+        this.str = `{Interval: [${this.#leftEndpoint.str}, ${this.#rightEndpoint.str}], Length: ${this.len.reduce().str}}`
     }
 
     get len() {

--- a/src/models/interval_collection.js
+++ b/src/models/interval_collection.js
@@ -37,21 +37,6 @@ class IntervalArr {
         }
     }
 
-    // the smallest division of a line segment required to represent all of the intervals in the collection, ie 1 over the lcm of the denominators of the endpoints
-    // eg: given [ 1/2, 3/5, 9/20 ], the smallest fractional unit is 1/20
-    // eg: given [ 1/5, 3/9, 4/7], the smallest fractional unit is 1/315
-    smallestInterval() {
-
-        let denominators = []
-
-        this.collection.forEach( interval => {
-            denominators.push(interval.left.den)
-            denominators.push(interval.right.den)
-        })
-
-        return new Fraction(1, lcm(denominators))
-    }
-
     // convert all fractions to use a common denominator - used for display purposes
     commonDen() {
         let denominators = []
@@ -66,11 +51,6 @@ class IntervalArr {
         let common = this.collection.map( interval => {
             const Lmultiple     = smallestDen / interval.left.den
             const Rmultiple     = smallestDen / interval.right.den
-            //const newLeft       = interval.left.mult(Lmultiple)
-            //const newLeft       = new Fraction(interval.left.num * Lmultiple, interval.left.den * Lmultiple)
-            //const newRight      = interval.right.mult(Rmultiple)
-            //const newRight      = new Fraction(interval.right.num * Rmultiple, interval.right.den * Rmultiple)
-            //debugger
             const tempSeg = new Interval(
                 new Fraction(interval.left.num * Lmultiple, interval.left.den * Lmultiple),
                 new Fraction(interval.right.num * Rmultiple, interval.right.den * Rmultiple)
@@ -119,10 +99,6 @@ class IntervalCollection {
             g.push_(new Interval( this.intervals.all[i].right, this.intervals.all[i+1].left))
         }
         return g
-    }
-
-    smallestInterval() {
-        return this.#myIntervals.smallestInterval()
     }
 
     concat_(intervalArr) {

--- a/src/models/interval_collection.js
+++ b/src/models/interval_collection.js
@@ -117,7 +117,14 @@ class IntervalCollection {
     concat_(intervalArr) {
         this.#myIntervals.all.concat_(intervalArr)
     }
+
+    forEach(cb) {
+        for(let i = 0; i < this.count; i+=1){
+            cb(this.#myIntervals.all[i], i, this)
+        }
+    }
 }
+
 export default IntervalCollection
 
 if(process.env['NODE_ENV'] === 'test') {

--- a/src/models/interval_collection.js
+++ b/src/models/interval_collection.js
@@ -56,7 +56,6 @@ class IntervalArr {
 
     // convert all fractions to use a common denominator - used for display purposes
     commonDen() {
-        // this function assumes that the smallest interval will have a 1 in the numerator - always true for 3/4, unusre if true for others
         let denominators = []
 
         this.collection.forEach( interval => {
@@ -69,10 +68,12 @@ class IntervalArr {
         let common = this.collection.map( interval => {
             const Lmultiple     = smallestDen / interval.left.den
             const Rmultiple     = smallestDen / interval.right.den
-            const newLeft       = new Fraction(interval.left.num * Lmultiple, interval.left.den * Lmultiple)
-            const newRight      = new Fraction(interval.right.num * Rmultiple, interval.right.den * Rmultiple)
+            //const newLeft       = interval.left.mult(Lmultiple)
+            //const newLeft       = new Fraction(interval.left.num * Lmultiple, interval.left.den * Lmultiple)
+            //const newRight      = interval.right.mult(Rmultiple)
+            //const newRight      = new Fraction(interval.right.num * Rmultiple, interval.right.den * Rmultiple)
 
-            const tempSeg = new Interval(newLeft, newRight)
+            const tempSeg = new Interval(interval.left.mult(Lmultiple), interval.right.mult(Rmultiple))
             return tempSeg
         })
         return common
@@ -83,7 +84,7 @@ class IntervalArr {
 class IntervalCollection {
     #myIntervals
 
-    // pass the gaps or intervals arr (or any arr of intervals), returns an array of the segments converted to the lowest common denominator
+    // pass the gaps or intervals arr (or any arr of intervals)
     constructor( intervalsArrArg ){
         try {
             checkArrContents(intervalsArrArg, 'Interval')

--- a/src/models/interval_collection.js
+++ b/src/models/interval_collection.js
@@ -57,7 +57,15 @@ class IntervalArr {
     // convert all fractions to use a common denominator - used for display purposes
     commonDen() {
         // this function assumes that the smallest interval will have a 1 in the numerator - always true for 3/4, unusre if true for others
-        let smallestDen = this.smallestInterval().den
+        let denominators = []
+
+        this.collection.forEach( interval => {
+            denominators.push(interval.left.den)
+            denominators.push(interval.right.den)
+        })
+
+        let smallestDen = lcm(denominators)
+
         let common = this.collection.map( interval => {
             const Lmultiple     = smallestDen / interval.left.den
             const Rmultiple     = smallestDen / interval.right.den
@@ -86,6 +94,7 @@ class IntervalCollection {
         this.#myIntervals = new IntervalArr(intervalsArrArg)
         // count of intervals in the collection
         this.count = this.#myIntervals.collection.length
+        this.str = `{IntervalCollection - count: ${this.count}, collection: ${this.intervals.all.map(interval => interval.str)}}`
     }
 
     get intervals() {

--- a/src/models/interval_collection.js
+++ b/src/models/interval_collection.js
@@ -25,8 +25,6 @@ class IntervalArr {
         } else if ( this.collection.length > 0 && interval.left.lessThan(this.collection[this.collection.length - 1].right) ) {
             throw new IntervalRangeError(`intervals must appear in order from left to right, starting at a minimum 0/1 and ending at a maximum of 1/1. The last endpoint of the interval collection is ${this.collection[this.collection.length - 1].right.str} and you attempted to append an interval starting at ${interval.left.str}, which is not allowed.`)
         }
-
-    //needs check to make sure the new interval's LHS endpoint is greater than the last item in the array's RHS endpoint
         this.collection.push(interval)
     }
 
@@ -72,8 +70,11 @@ class IntervalArr {
             //const newLeft       = new Fraction(interval.left.num * Lmultiple, interval.left.den * Lmultiple)
             //const newRight      = interval.right.mult(Rmultiple)
             //const newRight      = new Fraction(interval.right.num * Rmultiple, interval.right.den * Rmultiple)
-
-            const tempSeg = new Interval(interval.left.mult(Lmultiple), interval.right.mult(Rmultiple))
+            //debugger
+            const tempSeg = new Interval(
+                new Fraction(interval.left.num * Lmultiple, interval.left.den * Lmultiple),
+                new Fraction(interval.right.num * Rmultiple, interval.right.den * Rmultiple)
+            )
             return tempSeg
         })
         return common

--- a/src/shared/cantor.js
+++ b/src/shared/cantor.js
@@ -2,7 +2,6 @@ import Fraction from '../models/fraction'
 import Interval from '../models/interval'
 import IntervalCollection from '../models/interval_collection'
 import { ValueError } from './errors'
-import { lcm } from './utils'
 
 // cantor3_4
 // 0. given n number of iterations
@@ -16,8 +15,28 @@ import { lcm } from './utils'
 // 8.   push myCol to results to save the step for display later
 // 9.   bump counter
 //
+//
 
-export function removeIntervals(interval, numSegments, toRemove){
+// returns an array of IntervalCollections, where each IntervalCollection is one iteration of Cantor
+export function cantor(numSegments, toRemove, numIter) {
+    let results = []
+    let iterResults = []
+    let myCollection = new IntervalCollection([Interval.unit])
+    while(numIter > 0){
+        myCollection.forEach( interval => {
+            debugger // eslint-disable-line
+            let res = removeIntervals(interval, numSegments, toRemove)
+            iterResults = iterResults.concat(res)
+        })
+        results.push(new IntervalCollection(iterResults))
+        iterResults = []
+        myCollection = results[results.length - 1]
+        numIter = numIter - 1
+    }
+    return results
+}
+
+function removeIntervals(interval, numSegments, toRemove){
     if(toRemove.includes(1) || toRemove.includes(numSegments)){
         throw new ValueError(`Cannot remove the first or last segment in an interval: you asked to remove ${toRemove}`)
     }
@@ -43,4 +62,8 @@ export function removeIntervals(interval, numSegments, toRemove){
     }
 
     return result
+}
+
+if(process.env['NODE_ENV'] === 'test') {
+    exports.removeIntervals = removeIntervals
 }

--- a/src/shared/cantor.js
+++ b/src/shared/cantor.js
@@ -3,31 +3,34 @@ import Interval from '../models/interval'
 import IntervalCollection from '../models/interval_collection'
 import { ValueError } from './errors'
 
-// cantor3_4
-// 0. given n number of iterations
-// 1. create "mycol" IntervalCollection with 1 interval from 0/1 to 1/1
-// 2. create empty "results" IntervalCollection
-// 3. while iterations > 0
-// 4.   "currResults" Array = []
-// 5.   for each Interval in mycol
-// 6.       call function (remove third) that returns two new Intervals, wwhich get pushed to currResults
-// 7.   create "myCol" IntervalCollection passing currResults as argument
-// 8.   push myCol to results to save the step for display later
-// 9.   bump counter
-//
-//
+// in case I ever decide to look into alternating the segments between iterations, I removed most of the utility functions from the class to keep the flexibility that was lost when everything was tied to an instance
 
 // returns an array of IntervalCollections, where each IntervalCollection is one iteration of Cantor
-class Cantor {
-    #iterCount
+export default class Cantor {
     constructor( numSegments = 3, toRemove = [2], numIter = 1 ){
         if(toRemove.includes(1) || toRemove.includes(numSegments)){
             throw new ValueError(`Cannot remove the first or last segment in an interval: you asked to remove ${toRemove}`)
         }
+        toRemove = toRemove.sort( (a,b) => a-b )
+
         this.numSegments = numSegments
         this.toRemove = toRemove
-        this.#iterCount = numIter
         this.iterations = []
+
+        // calculate the Cantor iterations
+        let iterResults = []
+        let myCollection = new IntervalCollection([Interval.unit])
+
+        while(numIter > 0){
+            myCollection.forEach( interval => {
+                let res = removeIntervals(interval, numSegments, toRemove)
+                iterResults = iterResults.concat(res)
+            })
+            this.iterations.push(new IntervalCollection(iterResults))
+            iterResults = []
+            myCollection = this.iterations[this.iterations.length - 1]
+            numIter -= 1
+        }
     }
 
     get numIter(){
@@ -36,19 +39,22 @@ class Cantor {
 
 }
 
-function removeIntervals(){
+function removeIntervals(interval, numSegments, toRemove){
+    if(toRemove.includes(1) || toRemove.includes(numSegments)){
+        throw new ValueError(`Cannot remove the first or last segment in an interval: you asked to remove ${toRemove}`)
+    }
 
     // sort asc
     toRemove.sort( (a,b) => a-b )
 
     let commonInt = interval.commonDen()
     commonInt = commonInt.commonDen(commonInt.left.den * numSegments)
-    let cDen = commonInt.left.den
-    let segmentLength = new Fraction(commonInt.length.num, cDen)
+    let segmentLength = commonInt.len.equals(Fraction.unit)
+        ? new Fraction(1, numSegments)
+        : new Fraction(commonInt.len.num, commonInt.len.den * numSegments)
 
     //let toRemoveInt = toRemove.map( seg => new Interval(new Fraction(commonInt.left.num + seg - 1, cDen), new Fraction(commonInt.left.num + seg, cDen)) )
     let toRemoveInt = convertSegmentsToIntervals(commonInt, segmentLength, toRemove)
-    debugger
     let result = [commonInt]
 
     while(toRemoveInt.length > 0){
@@ -75,65 +81,25 @@ function convertSegmentsToIntervals(interval, segmentLength, segNum){
             curr.push(segNum[i])
         } else if ( curr.length > 0 ){
             // the following digit is not sequential, but the current digit is the end of a sequential string of digits
-            let newInterval = new Interval( new Fraction(interval.left.num + ((curr.shift() - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num),segmentLength.den) )
+            let newInterval = new Interval(
+                interval.left.add(segmentLength.mult(curr.shift() - 1)),
+                interval.left.add(segmentLength.mult(segNum[i]))
+            )
+           // let newInterval = new Interval( new Fraction(interval.left.num + ((curr.shift() - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num), segmentLength.den) )
             intervals.push(newInterval)
             curr = []
         } else {
             // current digit is not part of any sequential string
-            let newInterval = new Interval( new Fraction(interval.left.num + ((segNum[i] - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num), segmentLength.den))
+           // let newInterval = new Interval( new Fraction(interval.left.num + ((segNum[i] - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num), segmentLength.den))
+            let newInterval = new Interval(
+                interval.left.add(segmentLength.mult(segNum[i]-1)),
+                interval.left.add(segmentLength.mult(segNum[i]))
+            )
             intervals.push(newInterval)
         }
     }
 
     return intervals
-}
-
-function runIterations(){
-    let results = []
-    let iterResults = []
-    let myCollection = new IntervalCollection([Interval.unit])
-
-    while(numIter > 0){
-        myCollection.forEach( interval => {
-            debugger
-            let res = removeIntervals(interval, numSegments, toRemove)
-            iterResults = iterResults.concat(res)
-        })
-        results.push(new IntervalCollection(iterResults))
-        iterResults = []
-        myCollection = results[results.length - 1]
-        numIter = numIter - 1
-    }
-    return results
-}
-
-function removeIntervals(interval, numSegments, toRemove){
-    if(toRemove.includes(1) || toRemove.includes(numSegments)){
-        throw new ValueError(`Cannot remove the first or last segment in an interval: you asked to remove ${toRemove}`)
-    }
-
-    // sort asc
-    toRemove.sort( (a,b) => a-b )
-
-    let commonInt = interval.commonDen()
-    commonInt = commonInt.commonDen(commonInt.left.den * numSegments)
-    let cDen = commonInt.left.den
-
-    //let toRemoveInt = toRemove.map( seg => new Interval(new Fraction(commonInt.left.num + seg - 1, cDen), new Fraction(commonInt.left.num + seg, cDen)) )
-    let toRemoveInt = convertSegmentsToIntervals(commonInt, cDen, toRemove)
-    debugger
-    let result = [commonInt]
-
-    while(toRemoveInt.length > 0){
-        let curr = result.pop()
-        if(curr === undefined){
-            throw new Error('u messed up')
-        }
-        let seg = toRemoveInt.shift()
-        result = result.concat(curr.subtract(seg))
-    }
-
-    return result
 }
 
 if(process.env['NODE_ENV'] === 'test') {

--- a/src/shared/cantor.js
+++ b/src/shared/cantor.js
@@ -1,0 +1,53 @@
+import Fraction from '../models/fraction'
+import Interval from '../models/interval'
+import IntervalCollection from '../models/interval_collection'
+
+// cantor3_4
+// 0. given n number of iterations
+// 1. create "mycol" IntervalCollection with 1 interval from 0/1 to 1/1
+// 2. create empty "results" IntervalCollection
+// 3. while iterations > 0
+// 4.   "currResults" Array = []
+// 5.   for each Interval in mycol
+// 6.       call function (remove third) that returns two new Intervals, wwhich get pushed to currResults
+// 7.   create "myCol" IntervalCollection passing currResults as argument
+// 8.   push myCol to results to save the step for display later
+// 9.   bump counter
+//
+// remove_interval
+// ***** will not handle removal of adjacent intervals at the moment
+// given:   an interval - myint,
+//          array of integers representing the numbered segments to remove - toRem
+//              (each integer must be greater than 1 and less than the common denominator [exclude end segments])
+//
+//  1. result = []
+//  2. let fooL = myint.left
+//  3. while toRem is not empty
+//  4.      pop p off of toRem
+//  5.      let fooR = Frac(p-1, den)
+//  6.      let bar = Interval(fooL, fooR)
+//  7       result.push(bar)
+//  8.      let fooL = Frac(p, den)
+//  9. when toRem is empty
+//  10. let fooR = Frac(fooL, myint.right)
+//
+
+function removeInterval(interval, toRemove){
+    let result = []
+    let pointL = interval.left
+    let commonInt = interval.commonDen()
+    let commonDen = commonInt.left.den
+    //
+    // at this point, need to check that the numbers in the array are valid
+    // need to check if any numbers are sequential. If so, combine the segments into one gap
+    while(toRemove.length > 0){
+        let segNum = toRemove.shift()
+
+        let pointR = new Fraction(segNum - 1, commonDen)
+        let newInt = new Interval(pointL, pointR)
+        results.push(newInt)
+        let pointL = new Fraction(segNum, commonDen)
+    }
+
+    return result
+}

--- a/src/shared/cantor.js
+++ b/src/shared/cantor.js
@@ -20,7 +20,10 @@ import { ValueError } from './errors'
 // returns an array of IntervalCollections, where each IntervalCollection is one iteration of Cantor
 class Cantor {
     #iterCount
-    constructor( numSegments, toRemove, numIter ){
+    constructor( numSegments = 3, toRemove = [2], numIter = 1 ){
+        if(toRemove.includes(1) || toRemove.includes(numSegments)){
+            throw new ValueError(`Cannot remove the first or last segment in an interval: you asked to remove ${toRemove}`)
+        }
         this.numSegments = numSegments
         this.toRemove = toRemove
         this.#iterCount = numIter
@@ -31,10 +34,9 @@ class Cantor {
         return this.iterations.length
     }
 
-    removeIntervals(){
-    if(toRemove.includes(1) || toRemove.includes(numSegments)){
-        throw new ValueError(`Cannot remove the first or last segment in an interval: you asked to remove ${toRemove}`)
-    }
+}
+
+function removeIntervals(){
 
     // sort asc
     toRemove.sort( (a,b) => a-b )
@@ -59,55 +61,51 @@ class Cantor {
     }
 
     return result
-    }
+}
 
-    // returns the array of intervals to remove
-    convertSegmentsToIntervals(interval, segmentLength, segNum){
-        let curr = []
-        let intervals = []
 
-        for(let i = 0; i < segNum.length; i++){
-            if(i !== segNum.length - 1 && segNum[i] + 1 === segNum[i + 1]){
+// returns the array of intervals to remove
+function convertSegmentsToIntervals(interval, segmentLength, segNum){
+    let curr = []
+    let intervals = []
+
+    for(let i = 0; i < segNum.length; i++){
+        if(i !== segNum.length - 1 && segNum[i] + 1 === segNum[i + 1]){
             // numbers are sequential
-                curr.push(segNum[i])
-            } else if ( curr.length > 0 ){
+            curr.push(segNum[i])
+        } else if ( curr.length > 0 ){
             // the following digit is not sequential, but the current digit is the end of a sequential string of digits
-                let newInterval = new Interval( new Fraction(interval.left.num + ((curr.shift() - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num),segmentLength.den) )
-                intervals.push(newInterval)
-                curr = []
-            } else {
+            let newInterval = new Interval( new Fraction(interval.left.num + ((curr.shift() - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num),segmentLength.den) )
+            intervals.push(newInterval)
+            curr = []
+        } else {
             // current digit is not part of any sequential string
-                let newInterval = new Interval( new Fraction(interval.left.num + ((segNum[i] - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num), segmentLength.den))
-                intervals.push(newInterval)
-            }
+            let newInterval = new Interval( new Fraction(interval.left.num + ((segNum[i] - 1) * segmentLength.num), segmentLength.den), new Fraction(interval.left.num + (segNum[i] * segmentLength.num), segmentLength.den))
+            intervals.push(newInterval)
         }
-
-        return intervals
-    }
-    runIterations(){
-        let results = []
-        let iterResults = []
-        let myCollection = new IntervalCollection([Interval.unit])
-
-        while(numIter > 0){
-            myCollection.forEach( interval => {
-                debugger
-                let res = removeIntervals(interval, numSegments, toRemove)
-                iterResults = iterResults.concat(res)
-            })
-            results.push(new IntervalCollection(iterResults))
-            iterResults = []
-            myCollection = results[results.length - 1]
-            numIter = numIter - 1
-        }
-        return results
     }
 
-
-}
-export function cantor(numSegments, toRemove, numIter) {
+    return intervals
 }
 
+function runIterations(){
+    let results = []
+    let iterResults = []
+    let myCollection = new IntervalCollection([Interval.unit])
+
+    while(numIter > 0){
+        myCollection.forEach( interval => {
+            debugger
+            let res = removeIntervals(interval, numSegments, toRemove)
+            iterResults = iterResults.concat(res)
+        })
+        results.push(new IntervalCollection(iterResults))
+        iterResults = []
+        myCollection = results[results.length - 1]
+        numIter = numIter - 1
+    }
+    return results
+}
 
 function removeIntervals(interval, numSegments, toRemove){
     if(toRemove.includes(1) || toRemove.includes(numSegments)){

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -78,7 +78,6 @@ if (process.env['NODE_ENV'] === 'test') {
     exports.gcd = gcd
 }
 
-
 export {
     lcm,
     type,

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -1,0 +1,53 @@
+import { removeIntervals as cantor } from '../shared/cantor'
+import { ValueError } from '../shared/errors'
+import Interval from '../models/interval'
+import Fraction from '../models/fraction'
+
+describe('Cantor Library', function() {
+    describe('removeIntervals', function() {
+        let unit = new Interval(new Fraction(0, 1), new Fraction(1, 1))
+
+        it('allows removal of one segment from the unit interval and returns two intervals', function() {
+            // needs more cases
+            let res = cantor(unit, 5, [2])
+
+            expect(res.length).toEqual(2)
+            expect(res[0].left.equals(new Fraction(0, 5))).toBeTruthy()
+            expect(res[0].right.equals(new Fraction(1, 5))).toBeTruthy()
+            expect(res[1].left.equals(new Fraction(2, 5))).toBeTruthy()
+            expect(res[1].right.equals(new Fraction(5, 5))).toBeTruthy()
+        })
+
+        it('allows removal of two segments from the unit interval and returns the remaining three intervals', function() {
+            let res = cantor(unit, 5, [2, 4])
+            expect(res.length).toEqual(3)
+            expect(res[0].left.equals(new Fraction(0, 5))).toBeTruthy()
+            expect(res[0].right.equals(new Fraction(1, 5))).toBeTruthy()
+            expect(res[1].left.equals(new Fraction(2, 5))).toBeTruthy()
+            expect(res[1].right.equals(new Fraction(3, 5))).toBeTruthy()
+            expect(res[2].left.equals(new Fraction(4, 5))).toBeTruthy()
+            expect(res[2].right.equals(new Fraction(5, 5))).toBeTruthy()
+        })
+
+        it('allows removal of two segments from any given interval and returns the remaining three intervals', function() {
+            let hh = new Interval(new Fraction(2, 5), new Fraction(3, 5))
+            let res = cantor(hh, 5, [2, 4])
+
+            expect(res.length).toEqual(3)
+            expect(res[0].left.equals(new Fraction(10, 25))).toBeTruthy()
+            expect(res[0].right.equals(new Fraction(11, 25))).toBeTruthy()
+            expect(res[1].left.equals(new Fraction(12, 25))).toBeTruthy()
+            expect(res[1].right.equals(new Fraction(13, 25))).toBeTruthy()
+            expect(res[2].left.equals(new Fraction(14, 25))).toBeTruthy()
+            expect(res[2].right.equals(new Fraction(15, 25))).toBeTruthy()
+        })
+
+        it('fails when attempting to remove the first interval', function(){
+            expect(() => cantor(unit, 5, [1, 3])).toThrow(ValueError)
+        })
+
+        it('fails when attempting to remove the last interval', function(){
+            expect(() => cantor(unit, 5, [3, 5])).toThrow(ValueError)
+        })
+    })
+})

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -7,39 +7,67 @@ import Fraction from '../models/fraction'
 describe('Cantor Library', function() {
     describe('removeIntervals', function() {
 
-        it('allows removal of one segment from the unit interval and returns two intervals', function() {
-            // needs more cases
+        describe('one centered gap of size 1/5, taking [2] from a 5-segment line', function() {
             let res = removeIntervals(Interval.unit, 5, [2])
 
-            expect(res.length).toEqual(2)
-            expect(res[0].left.equals(new Fraction(0, 5))).toBeTruthy()
-            expect(res[0].right.equals(new Fraction(1, 5))).toBeTruthy()
-            expect(res[1].left.equals(new Fraction(2, 5))).toBeTruthy()
-            expect(res[1].right.equals(new Fraction(5, 5))).toBeTruthy()
+            it('produces 2 intervals', function(){
+                expect(res.length).toEqual(2)
+            })
+
+            describe.each`
+                index | left        |   right
+                ${0}  | ${[0, 5]}   | ${[1, 5]}
+                ${1}  | ${[2, 5]}   | ${[5, 5]}
+            `('removes one gap', ({index, left, right}) => {
+                it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                    let interval = res[index]
+                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                })
+            })
         })
 
-        it('allows removal of two segments from the unit interval and returns the remaining three intervals', function() {
+        describe('two centered gaps of size 1/5, taking [2, 4] from a 5-segment line', function() {
             let res = removeIntervals(Interval.unit, 5, [2, 4])
-            expect(res.length).toEqual(3)
-            expect(res[0].left.equals(new Fraction(0, 5))).toBeTruthy()
-            expect(res[0].right.equals(new Fraction(1, 5))).toBeTruthy()
-            expect(res[1].left.equals(new Fraction(2, 5))).toBeTruthy()
-            expect(res[1].right.equals(new Fraction(3, 5))).toBeTruthy()
-            expect(res[2].left.equals(new Fraction(4, 5))).toBeTruthy()
-            expect(res[2].right.equals(new Fraction(5, 5))).toBeTruthy()
+
+            it('produces 3 intervals', function(){
+                expect(res.length).toEqual(3)
+            })
+
+            describe.each`
+                index | left        |   right
+                ${0}  | ${[0, 5]}   | ${[1, 5]}
+                ${1}  | ${[2, 5]}   | ${[3, 5]}
+                ${2}  | ${[4, 5]}   | ${[5, 5]}
+            `('removes one gap', ({index, left, right}) => {
+                it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                    let interval = res[index]
+                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                })
+            })
         })
 
-        it('allows removal of two segments from any given interval and returns the remaining three intervals', function() {
+        describe('two centered gaps of size 1/25, taking [2, 4] out of 5 sements on the interval [2/5, 3/5]', function(){
             let hh = new Interval(new Fraction(2, 5), new Fraction(3, 5))
             let res = removeIntervals(hh, 5, [2, 4])
 
-            expect(res.length).toEqual(3)
-            expect(res[0].left.equals(new Fraction(10, 25))).toBeTruthy()
-            expect(res[0].right.equals(new Fraction(11, 25))).toBeTruthy()
-            expect(res[1].left.equals(new Fraction(12, 25))).toBeTruthy()
-            expect(res[1].right.equals(new Fraction(13, 25))).toBeTruthy()
-            expect(res[2].left.equals(new Fraction(14, 25))).toBeTruthy()
-            expect(res[2].right.equals(new Fraction(15, 25))).toBeTruthy()
+            it('produces 3 intervals', function(){
+                expect(res.length).toEqual(3)
+            })
+
+            describe.each`
+                index | left        |   right
+                ${0}  | ${[10, 25]}   | ${[11, 25]}
+                ${1}  | ${[12, 25]}   | ${[13, 25]}
+                ${2}  | ${[14, 25]}   | ${[15, 25]}
+            `('removes one gap', ({index, left, right}) => {
+                it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                    let interval = res[index]
+                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                })
+            })
         })
 
         it('fails when attempting to remove the first interval', function(){
@@ -53,106 +81,208 @@ describe('Cantor Library', function() {
 
     describe('Cantor iterations', function(){
         describe('Standard Cantor: split into 3, remove middle', function(){
-            it('Performs 1 iteration of standard Cantor', function() {
+            describe('Performs 1 iteration of standard Cantor', function() {
                 let res = new Cantor(3, [2], 1)
-                expect(res.numIter).toEqual(1)
-                expect(res.iterations[0].count).toEqual(2)
 
-                let first = res.iterations[0].intervals.all[0]
-                expect(first.left.equals(new Fraction(0,3))).toBeTruthy()
-                expect(first.right.equals(new Fraction(1,3))).toBeTruthy()
+                it('produces 2 intervals', function(){
+                    expect(res.numIter).toEqual(1)
+                    expect(res.iterations[0].count).toEqual(2)
+                })
 
-                let second = res.iterations[0].intervals.all[1]
-                expect(second.left.equals(new Fraction(2,3))).toBeTruthy()
-                expect(second.right.equals(new Fraction(3,3))).toBeTruthy()
+                describe.each`
+                    iteration   | index | left          |   right
+                    ${0}        | ${0}  | ${[0, 3]}     | ${[1, 3]}
+                    ${0}        | ${1}  | ${[2, 3]}     | ${[3, 3]}
+                `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                    let interval = res.iterations[iteration].intervals.all[index]
+                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    })
+                })
             })
 
-            it('Performs 2 iterations of standard Cantor', function() {
+            describe('Performs 2 iterations of standard Cantor', function() {
                 let res = new Cantor(3, [2], 2)
-                expect(res.numIter).toEqual(2)
-                expect(res.iterations[0].count).toEqual(2)
 
-                let first = res.iterations[0].intervals.all[0]
-                expect(first.left.equals(new Fraction(0,3))).toBeTruthy()
-                expect(first.right.equals(new Fraction(1,3))).toBeTruthy()
-                let second = res.iterations[0].intervals.all[1]
-                expect(second.left.equals(new Fraction(2,3))).toBeTruthy()
-                expect(second.right.equals(new Fraction(3,3))).toBeTruthy()
+                it('produces 2 intervals on the first iteration, then 4 intervals for the second', function(){
+                    expect(res.numIter).toEqual(2)
+                    expect(res.iterations[0].count).toEqual(2)
+                    expect(res.iterations[1].count).toEqual(4)
+                })
 
-                expect(res.iterations[1].count).toEqual(4)
-                first = res.iterations[1].intervals.all[0]
-                expect(first.left.equals(new Fraction(0,9))).toBeTruthy()
-                expect(first.right.equals(new Fraction(1,9))).toBeTruthy()
-                second = res.iterations[1].intervals.all[1]
-                expect(second.left.equals(new Fraction(2,9))).toBeTruthy()
-                expect(second.right.equals(new Fraction(3,9))).toBeTruthy()
-                let third = res.iterations[1].intervals.all[2]
-                expect(third.left.equals(new Fraction(6,9))).toBeTruthy()
-                expect(third.right.equals(new Fraction(7,9))).toBeTruthy()
-                let fourth = res.iterations[1].intervals.all[3]
-                expect(fourth.left.equals(new Fraction(8,9))).toBeTruthy()
-                expect(fourth.right.equals(new Fraction(9,9))).toBeTruthy()
+                describe.each`
+                    iteration   | index | left          |   right
+                    ${0}        | ${0}  | ${[0, 3]}     | ${[1, 3]}
+                    ${0}        | ${1}  | ${[2, 3]}     | ${[3, 3]}
+                    ${1}        | ${0}  | ${[0, 9]}     | ${[1, 9]}
+                    ${1}        | ${1}  | ${[2, 9]}     | ${[3, 9]}
+                    ${1}        | ${2}  | ${[6, 9]}     | ${[7, 9]}
+                    ${1}        | ${3}  | ${[8, 9]}     | ${[9, 9]}
+                `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                        let interval = res.iterations[iteration].intervals.all[index]
+                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    })
+                })
             })
         })
 
         describe('Non-standard Cantor', function() {
-            it('Performs 1 iteration removing the 2nd and 4th segments of a unit interval divided into 5 segments', function(){
-                let res = new Cantor(5, [2, 4], 1)
-                expect(res.numIter).toEqual(1)
+            // TODO make this 2 iterations
+            describe('Two iterations removing two [2, 4] gaps of size 1 out of a 5-segmented line', function(){
+                let res = new Cantor(5, [2, 4], 2)
 
-                expect(res.iterations[0].count).toEqual(3)
+                it('produces 3 intervals on the first iteration, 9 on the second', function(){
+                    expect(res.numIter).toEqual(2)
+                    expect(res.iterations[0].count).toEqual(3)
+                    expect(res.iterations[1].count).toEqual(9)
+                })
 
-                let first = res.iterations[0].intervals.all[0]
-                expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
-                expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
-                let second = res.iterations[0].intervals.all[1]
-                expect(second.left.equals(new Fraction(2,5))).toBeTruthy()
-                expect(second.right.equals(new Fraction(3,5))).toBeTruthy()
-                let third = res.iterations[0].intervals.all[2]
-                expect(third.left.equals(new Fraction(4,5))).toBeTruthy()
-                expect(third.right.equals(new Fraction(5,5))).toBeTruthy()
-
+                describe.each`
+                    iteration   | index | left          |   right
+                    ${0}        | ${0}  | ${[0, 5]}     | ${[1, 5]}
+                    ${0}        | ${1}  | ${[2, 5]}     | ${[3, 5]}
+                    ${0}        | ${2}  | ${[4, 5]}     | ${[5, 5]}
+                    ${1}        | ${0}  | ${[0, 25]}    | ${[1, 25]}
+                    ${1}        | ${1}  | ${[2, 25]}    | ${[3, 25]}
+                    ${1}        | ${2}  | ${[4, 25]}    | ${[5, 25]}
+                    ${1}        | ${3}  | ${[10, 25]}   | ${[11, 25]}
+                    ${1}        | ${4}  | ${[12, 25]}   | ${[13, 25]}
+                    ${1}        | ${5}  | ${[14, 25]}   | ${[15, 25]}
+                    ${1}        | ${6}  | ${[20, 25]}   | ${[21, 25]}
+                    ${1}        | ${7}  | ${[22, 25]}   | ${[23, 25]}
+                    ${1}        | ${8}  | ${[24, 25]}   | ${[25, 25]}
+                `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                    let interval = res.iterations[iteration].intervals.all[index]
+                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    })
+                })
             })
 
-            it('Performs 1 iteration removing the 2nd and 3rd segments of a unit interval divided into 5 segments', function() {
-                let res = new Cantor(5, [2, 3], 1)
-                expect(res.numIter).toEqual(1)
-                expect(res.iterations[0].count).toEqual(2)
-                let first = res.iterations[0].intervals.all[0]
-                expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
-                expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
-                let second = res.iterations[0].intervals.all[1]
-                expect(second.left.equals(new Fraction(3,5))).toBeTruthy()
-                expect(second.right.equals(new Fraction(5,5))).toBeTruthy()
-
-            })
-
-            it('Performs 2 iterations removing the 2nd and 3rd segments of a unit interval dividided into 5', function(){
+            describe('two iterations removing one gap of size 2, taking [2, 3] from a 5-segmented line', function(){
                 let res = new Cantor(5, [2, 3], 2)
 
-                expect(res.numIter).toEqual(2)
-                expect(res.iterations[0].count).toEqual(2)
-                let first = res.iterations[0].intervals.all[0]
-                expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
-                expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
-                let second = res.iterations[0].intervals.all[1]
-                expect(second.left.equals(new Fraction(3,5))).toBeTruthy()
-                expect(second.right.equals(new Fraction(5,5))).toBeTruthy()
+                it('produces 2 intervals on first iteration, 4 on second', function(){
+                    expect(res.numIter).toEqual(2)
+                    expect(res.iterations[0].count).toEqual(2)
+                    expect(res.iterations[1].count).toEqual(4)
+                })
 
-                expect(res.iterations[1].count).toEqual(4)
-                first = res.iterations[1].intervals.all[0]
-                expect(first.left.equals(new Fraction(0,25))).toBeTruthy()
-                expect(first.right.equals(new Fraction(1,25))).toBeTruthy()
-                second = res.iterations[1].intervals.all[1]
-                expect(second.left.equals(new Fraction(3,25))).toBeTruthy()
-                expect(second.right.equals(new Fraction(5, 25))).toBeTruthy()
-                let third = res.iterations[1].intervals.all[2]
-                expect(third.left.equals(new Fraction(15,25))).toBeTruthy()
-                expect(third.right.equals(new Fraction(17,25))).toBeTruthy()
-                let fourth = res.iterations[1].intervals.all[3]
-                expect(fourth.left.equals(new Fraction(21,25))).toBeTruthy()
-                expect(fourth.right.equals(new Fraction(25,25))).toBeTruthy()
+                describe.each`
+                    iteration   | index | left          |   right
+                    ${0}        | ${0}  | ${[0, 5]}     | ${[1, 5]}
+                    ${0}        | ${1}  | ${[3, 5]}     | ${[5, 5]}
+                    ${1}        | ${0}  | ${[0, 25]}    | ${[1, 25]}
+                    ${1}        | ${1}  | ${[3, 25]}    | ${[5, 25]}
+                    ${1}        | ${2}  | ${[15, 25]}   | ${[17, 25]}
+                    ${1}        | ${3}  | ${[21, 25]}   | ${[25, 25]}
+                `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                    let interval = res.iterations[iteration].intervals.all[index]
+                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    })
+                })
             })
+
+            describe('one uncentered gap of size 3, taking [2, 3, 4] from a 6-segment line', function(){
+                let res = new Cantor(6, [2, 3, 4], 2)
+                describe.each`
+                    iteration   | index | left          |   right
+                    ${0}        | ${0}  | ${[0, 6]}     | ${[1, 6]}
+                    ${0}        | ${1}  | ${[4, 6]}     | ${[6, 6]}
+                    ${1}        | ${0}  | ${[0, 36]}    | ${[1, 36]}
+                    ${1}        | ${1}  | ${[4, 36]}    | ${[6, 36]}
+                    ${1}        | ${2}  | ${[12, 18]}   | ${[13, 18]}
+                    ${1}        | ${3}  | ${[16, 18]}   | ${[18, 18]}
+                    `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                        let interval = res.iterations[iteration].intervals.all[index]
+                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    })
+                })
+            })
+
+            describe('performs 2 iterations with one gap of size 2 followed by a gap of size 1, taking [2, 3, 5] from a 7-segment line', function(){
+                let res = new Cantor(7, [2, 3, 5], 2)
+                describe.each`
+                    iteration   | index | left          |   right
+                    ${0}        | ${0}  | ${[0, 7]}     | ${[1, 7]}
+                    ${0}        | ${1}  | ${[3, 7]}     | ${[4, 7]}
+                    ${0}        | ${2}  | ${[5, 7]}     | ${[7, 7]}
+                    ${1}        | ${0}  | ${[0, 49]}    | ${[1, 49]}
+                    ${1}        | ${1}  | ${[3, 49]}    | ${[4, 49]}
+                    ${1}        | ${2}  | ${[5, 49]}    | ${[7, 49]}
+                    ${1}        | ${3}  | ${[21, 49]}   | ${[22, 49]}
+                    ${1}        | ${4}  | ${[24, 49]}   | ${[25, 49]}
+                    ${1}        | ${5}  | ${[26, 49]}   | ${[28, 49]}
+                    ${1}        | ${6}  | ${[35, 49]}   | ${[37, 49]}
+                    ${1}        | ${7}  | ${[41, 49]}   | ${[43, 49]}
+                    ${1}        | ${8}  | ${[45, 49]}   | ${[49, 49]}
+                    `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                        let interval = res.iterations[iteration].intervals.all[index]
+                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    })
+                })
+            })
+
+            describe('performs 2 iterations with one gap of size 1 followed by a gap of size 2, taking [3, 5, 6] from a 7-segment line', function(){
+                let res = new Cantor(7, [3, 5, 6], 2)
+                describe.each`
+                    iteration   | index | left          |   right
+                    ${0}        | ${0}  | ${[0, 7]}     | ${[2, 7]}
+                    ${0}        | ${1}  | ${[3, 7]}     | ${[4, 7]}
+                    ${0}        | ${2}  | ${[6, 7]}     | ${[7, 7]}
+                    ${1}        | ${0}  | ${[0, 49]}    | ${[4, 49]}
+                    ${1}        | ${1}  | ${[6, 49]}    | ${[8, 49]}
+                    ${1}        | ${2}  | ${[12, 49]}   | ${[14, 49]}
+                    ${1}        | ${3}  | ${[21, 49]}   | ${[23, 49]}
+                    ${1}        | ${4}  | ${[24, 49]}   | ${[25, 49]}
+                    ${1}        | ${5}  | ${[27, 49]}   | ${[28, 49]}
+                    ${1}        | ${6}  | ${[42, 49]}   | ${[44, 49]}
+                    ${1}        | ${7}  | ${[45, 49]}   | ${[46, 49]}
+                    ${1}        | ${8}  | ${[48, 49]}   | ${[49, 49]}
+                    `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                        let interval = res.iterations[iteration].intervals.all[index]
+                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    })
+                })
+            })
+
+            describe('performs 2 iterations with two gaps of size 2, taking [3, 4, 6, 7] from an 8-segment line', function(){
+                let res = new Cantor(8, [3, 4, 6, 7], 2)
+                describe.each`
+                    iteration   | index | left          |   right
+                    ${0}        | ${0}  | ${[0, 8]}     | ${[2, 8]}
+                    ${0}        | ${1}  | ${[4, 8]}     | ${[5, 8]}
+                    ${0}        | ${2}  | ${[7, 8]}     | ${[8, 8]}
+                    ${1}        | ${0}  | ${[0, 32]}    | ${[2, 32]}
+                    ${1}        | ${1}  | ${[4, 32]}    | ${[5, 32]}
+                    ${1}        | ${2}  | ${[7, 32]}    | ${[8, 32]}
+                    ${1}        | ${3}  | ${[32, 64]}   | ${[34, 64]}
+                    ${1}        | ${4}  | ${[36, 64]}   | ${[37, 64]}
+                    ${1}        | ${5}  | ${[39, 64]}   | ${[40, 64]}
+                    ${1}        | ${6}  | ${[56, 64]}   | ${[58, 64]}
+                    ${1}        | ${7}  | ${[60, 64]}   | ${[61, 64]}
+                    ${1}        | ${8}  | ${[63, 64]}   | ${[64, 64]}
+                    `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
+                        let interval = res.iterations[iteration].intervals.all[index]
+                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    })
+                })
+            })
+
         })
     })
 })

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -1,4 +1,4 @@
-import { removeIntervals as cantor } from '../shared/cantor'
+import { removeIntervals, cantor } from '../shared/cantor'
 import { ValueError } from '../shared/errors'
 import Interval from '../models/interval'
 import Fraction from '../models/fraction'
@@ -9,7 +9,7 @@ describe('Cantor Library', function() {
 
         it('allows removal of one segment from the unit interval and returns two intervals', function() {
             // needs more cases
-            let res = cantor(unit, 5, [2])
+            let res = removeIntervals(unit, 5, [2])
 
             expect(res.length).toEqual(2)
             expect(res[0].left.equals(new Fraction(0, 5))).toBeTruthy()
@@ -19,7 +19,7 @@ describe('Cantor Library', function() {
         })
 
         it('allows removal of two segments from the unit interval and returns the remaining three intervals', function() {
-            let res = cantor(unit, 5, [2, 4])
+            let res = removeIntervals(unit, 5, [2, 4])
             expect(res.length).toEqual(3)
             expect(res[0].left.equals(new Fraction(0, 5))).toBeTruthy()
             expect(res[0].right.equals(new Fraction(1, 5))).toBeTruthy()
@@ -31,7 +31,7 @@ describe('Cantor Library', function() {
 
         it('allows removal of two segments from any given interval and returns the remaining three intervals', function() {
             let hh = new Interval(new Fraction(2, 5), new Fraction(3, 5))
-            let res = cantor(hh, 5, [2, 4])
+            let res = removeIntervals(hh, 5, [2, 4])
 
             expect(res.length).toEqual(3)
             expect(res[0].left.equals(new Fraction(10, 25))).toBeTruthy()
@@ -43,11 +43,80 @@ describe('Cantor Library', function() {
         })
 
         it('fails when attempting to remove the first interval', function(){
-            expect(() => cantor(unit, 5, [1, 3])).toThrow(ValueError)
+            expect(() => removeIntervals(unit, 5, [1, 3])).toThrow(ValueError)
         })
 
         it('fails when attempting to remove the last interval', function(){
-            expect(() => cantor(unit, 5, [3, 5])).toThrow(ValueError)
+            expect(() => removeIntervals(unit, 5, [3, 5])).toThrow(ValueError)
+        })
+    })
+
+    describe.only('Cantor iterations', function(){
+        describe('Standard Cantor: split into 3, remove middle', function(){
+            it('Performs 1 iteration of standard Cantor', function() {
+                let res = cantor(3, [2], 1)
+                expect(res.length).toEqual(1)
+                expect(res[0].count).toEqual(2)
+
+                let first = res[0].intervals.all[0]
+                expect(first.left.equals(new Fraction(0,3))).toBeTruthy()
+                expect(first.right.equals(new Fraction(1,3))).toBeTruthy()
+
+                let second = res[0].intervals.all[1]
+                expect(second.left.equals(new Fraction(2,3))).toBeTruthy()
+                expect(second.right.equals(new Fraction(3,3))).toBeTruthy()
+            })
+
+            it('Performs 2 iterations of standard Cantor', function() {
+                let res = cantor(3, [2], 2)
+                expect(res.length).toEqual(2)
+
+                expect(res[0].count).toEqual(2)
+                let first = res[0].intervals.all[0]
+                expect(first.left.equals(new Fraction(0,3))).toBeTruthy()
+                expect(first.right.equals(new Fraction(1,3))).toBeTruthy()
+                let second = res[0].intervals.all[1]
+                expect(second.left.equals(new Fraction(2,3))).toBeTruthy()
+                expect(second.right.equals(new Fraction(3,3))).toBeTruthy()
+
+                expect(res[1].count).toEqual(4)
+                first = res[1].intervals.all[0]
+                expect(first.left.equals(new Fraction(0,9))).toBeTruthy()
+                expect(first.right.equals(new Fraction(1,9))).toBeTruthy()
+                second = res[1].intervals.all[1]
+                expect(second.left.equals(new Fraction(2,9))).toBeTruthy()
+                expect(second.right.equals(new Fraction(3,9))).toBeTruthy()
+                let third = res[1].intervals.all[2]
+                expect(third.left.equals(new Fraction(6,9))).toBeTruthy()
+                expect(third.right.equals(new Fraction(7,9))).toBeTruthy()
+                let fourth = res[1].intervals.all[3]
+                expect(fourth.left.equals(new Fraction(8,9))).toBeTruthy()
+                expect(fourth.right.equals(new Fraction(9,9))).toBeTruthy()
+            })
+        })
+
+        describe('Non-standard Cantor', function() {
+            it('Performs 1 iteration removing the 2nd and 4th segments of a unit interval divided into 5 segments', function(){
+                let res = cantor(5, [2, 4], 1)
+                expect(res.length).toEqual(1)
+
+                expect(res[0].count).toEqual(3)
+
+                let first = res[0].intervals.all[0]
+                expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
+                expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
+                let second = res[0].intervals.all[1]
+                expect(second.left.equals(new Fraction(2,5))).toBeTruthy()
+                expect(second.right.equals(new Fraction(3,5))).toBeTruthy()
+                let third = res[0].intervals.all[2]
+                expect(third.left.equals(new Fraction(4,5))).toBeTruthy()
+                expect(third.right.equals(new Fraction(5,5))).toBeTruthy()
+
+            })
+
+            it.skip('Performs 1 iteration removing the 2nd and 3rd segments of a unit interval divided into 5 segments', function() {
+                console.log('have not implemented this yet')
+            })
         })
     })
 })

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -1,5 +1,5 @@
-import { removeIntervals } from '../shared/cantor'
-import Cantor from '../shared/cantor'
+import { removeIntervals } from '../models/cantor'
+import Cantor from '../models/cantor'
 import { ValueError } from '../shared/errors'
 import Interval from '../models/interval'
 import Fraction from '../models/fraction'

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -21,8 +21,8 @@ describe('Cantor Library', function() {
             `('removes one gap', ({index, left, right}) => {
                 it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res[index]
-                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                 })
             })
         })
@@ -42,8 +42,8 @@ describe('Cantor Library', function() {
             `('removes one gap', ({index, left, right}) => {
                 it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res[index]
-                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                 })
             })
         })
@@ -64,8 +64,8 @@ describe('Cantor Library', function() {
             `('removes one gap', ({index, left, right}) => {
                 it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res[index]
-                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                 })
             })
         })
@@ -96,8 +96,8 @@ describe('Cantor Library', function() {
                 `('performs 2 iterations', ({iteration, index, left, right}) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res.iterations[iteration].intervals.all[index]
-                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -122,8 +122,8 @@ describe('Cantor Library', function() {
                 `('performs 2 iterations', ({iteration, index, left, right}) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
-                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                        expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -157,8 +157,8 @@ describe('Cantor Library', function() {
                 `('performs 2 iterations', ({iteration, index, left, right}) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res.iterations[iteration].intervals.all[index]
-                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -183,8 +183,8 @@ describe('Cantor Library', function() {
                 `('performs 2 iterations', ({iteration, index, left, right}) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res.iterations[iteration].intervals.all[index]
-                    expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -202,8 +202,8 @@ describe('Cantor Library', function() {
                     `('performs 2 iterations', ({iteration, index, left, right}) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
-                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                        expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -227,8 +227,8 @@ describe('Cantor Library', function() {
                     `('performs 2 iterations', ({iteration, index, left, right}) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
-                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                        expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -252,8 +252,8 @@ describe('Cantor Library', function() {
                     `('performs 2 iterations', ({iteration, index, left, right}) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
-                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                        expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -277,12 +277,11 @@ describe('Cantor Library', function() {
                     `('performs 2 iterations', ({iteration, index, left, right}) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
-                        expect(interval.left.equals( new Fraction(left[0], left[1]) )).toBeTruthy()
-                        expect(interval.right.equals( new Fraction(right[0], right[1]) )).toBeTruthy()
+                        expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
-
         })
     })
 })

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -18,7 +18,7 @@ describe('Cantor Library', function() {
                 index | left        |   right
                 ${0}  | ${[0, 5]}   | ${[1, 5]}
                 ${1}  | ${[2, 5]}   | ${[5, 5]}
-            `('removes one gap', ({index, left, right}) => {
+            `('removes one gap', ({ index, left, right }) => {
                 it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res[index]
                     expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
@@ -39,7 +39,7 @@ describe('Cantor Library', function() {
                 ${0}  | ${[0, 5]}   | ${[1, 5]}
                 ${1}  | ${[2, 5]}   | ${[3, 5]}
                 ${2}  | ${[4, 5]}   | ${[5, 5]}
-            `('removes one gap', ({index, left, right}) => {
+            `('removes one gap', ({ index, left, right }) => {
                 it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res[index]
                     expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
@@ -61,7 +61,7 @@ describe('Cantor Library', function() {
                 ${0}  | ${[10, 25]}   | ${[11, 25]}
                 ${1}  | ${[12, 25]}   | ${[13, 25]}
                 ${2}  | ${[14, 25]}   | ${[15, 25]}
-            `('removes one gap', ({index, left, right}) => {
+            `('removes one gap', ({ index, left, right }) => {
                 it(`resulting in intervals [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                     let interval = res[index]
                     expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
@@ -93,11 +93,11 @@ describe('Cantor Library', function() {
                     iteration   | index | left          |   right
                     ${0}        | ${0}  | ${[0, 3]}     | ${[1, 3]}
                     ${0}        | ${1}  | ${[2, 3]}     | ${[3, 3]}
-                `('performs 2 iterations', ({iteration, index, left, right}) => {
+                `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                    let interval = res.iterations[iteration].intervals.all[index]
-                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
+                        let interval = res.iterations[iteration].intervals.all[index]
+                        expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -119,7 +119,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${1}  | ${[2, 9]}     | ${[3, 9]}
                     ${1}        | ${2}  | ${[6, 9]}     | ${[7, 9]}
                     ${1}        | ${3}  | ${[8, 9]}     | ${[9, 9]}
-                `('performs 2 iterations', ({iteration, index, left, right}) => {
+                `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
@@ -130,7 +130,6 @@ describe('Cantor Library', function() {
         })
 
         describe('Non-standard Cantor', function() {
-            // TODO make this 2 iterations
             describe('Two iterations removing two [2, 4] gaps of size 1 out of a 5-segmented line', function(){
                 let res = new Cantor(5, [2, 4], 2)
 
@@ -154,11 +153,11 @@ describe('Cantor Library', function() {
                     ${1}        | ${6}  | ${[20, 25]}   | ${[21, 25]}
                     ${1}        | ${7}  | ${[22, 25]}   | ${[23, 25]}
                     ${1}        | ${8}  | ${[24, 25]}   | ${[25, 25]}
-                `('performs 2 iterations', ({iteration, index, left, right}) => {
+                `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                    let interval = res.iterations[iteration].intervals.all[index]
-                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
+                        let interval = res.iterations[iteration].intervals.all[index]
+                        expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -180,11 +179,11 @@ describe('Cantor Library', function() {
                     ${1}        | ${1}  | ${[3, 25]}    | ${[5, 25]}
                     ${1}        | ${2}  | ${[15, 25]}   | ${[17, 25]}
                     ${1}        | ${3}  | ${[21, 25]}   | ${[25, 25]}
-                `('performs 2 iterations', ({iteration, index, left, right}) => {
+                `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                    let interval = res.iterations[iteration].intervals.all[index]
-                    expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
-                    expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
+                        let interval = res.iterations[iteration].intervals.all[index]
+                        expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
+                        expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
                 })
             })
@@ -199,7 +198,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${1}  | ${[4, 36]}    | ${[6, 36]}
                     ${1}        | ${2}  | ${[12, 18]}   | ${[13, 18]}
                     ${1}        | ${3}  | ${[16, 18]}   | ${[18, 18]}
-                    `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
@@ -224,7 +223,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${6}  | ${[35, 49]}   | ${[37, 49]}
                     ${1}        | ${7}  | ${[41, 49]}   | ${[43, 49]}
                     ${1}        | ${8}  | ${[45, 49]}   | ${[49, 49]}
-                    `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
@@ -249,7 +248,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${6}  | ${[42, 49]}   | ${[44, 49]}
                     ${1}        | ${7}  | ${[45, 49]}   | ${[46, 49]}
                     ${1}        | ${8}  | ${[48, 49]}   | ${[49, 49]}
-                    `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
@@ -274,7 +273,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${6}  | ${[56, 64]}   | ${[58, 64]}
                     ${1}        | ${7}  | ${[60, 64]}   | ${[61, 64]}
                     ${1}        | ${8}  | ${[63, 64]}   | ${[64, 64]}
-                    `('performs 2 iterations', ({iteration, index, left, right}) => {
+                    `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
                         let interval = res.iterations[iteration].intervals.all[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -114,8 +114,45 @@ describe('Cantor Library', function() {
 
             })
 
-            it.skip('Performs 1 iteration removing the 2nd and 3rd segments of a unit interval divided into 5 segments', function() {
-                console.log('have not implemented this yet')
+            it('Performs 1 iteration removing the 2nd and 3rd segments of a unit interval divided into 5 segments', function() {
+                let res = cantor(5, [2, 3], 1)
+                expect(res.length).toEqual(1)
+                expect(res[0].count).toEqual(2)
+                let first = res[0].intervals.all[0]
+                expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
+                expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
+                let second = res[0].intervals.all[1]
+                expect(second.left.equals(new Fraction(3,5))).toBeTruthy()
+                expect(second.right.equals(new Fraction(5,5))).toBeTruthy()
+
+            })
+
+            it('Performs 2 iterations removing the 2nd and 3rd segments of a unit interval dividided into 5', function(){
+                let res = cantor(5, [2, 3], 2)
+
+                expect(res.length).toEqual(2)
+                expect(res[0].count).toEqual(2)
+                let first = res[0].intervals.all[0]
+                expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
+                expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
+                let second = res[0].intervals.all[1]
+                expect(second.left.equals(new Fraction(3,5))).toBeTruthy()
+                expect(second.right.equals(new Fraction(5,5))).toBeTruthy()
+
+                expect(res[1].count).toEqual(4)
+                first = res[1].intervals.all[0]
+                expect(first.left.equals(new Fraction(0,25))).toBeTruthy()
+                expect(first.right.equals(new Fraction(1,25))).toBeTruthy()
+                second = res[1].intervals.all[1]
+                expect(second.left.equals(new Fraction(3,25))).toBeTruthy()
+                expect(second.right.equals(new Fraction(5, 25))).toBeTruthy()
+                let third = res[1].intervals.all[2]
+                expect(third.left.equals(new Fraction(15,25))).toBeTruthy()
+                expect(third.right.num).toEqual(17)
+                expect(third.right.equals(new Fraction(17,25))).toBeTruthy()
+                let fourth = res[1].intervals.all[3]
+                expect(fourth.left.equals(new Fraction(21,25))).toBeTruthy()
+                expect(fourth.right.equals(new Fraction(25,25))).toBeTruthy()
             })
         })
     })

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -1,15 +1,15 @@
-import { removeIntervals, cantor } from '../shared/cantor'
+import { removeIntervals } from '../shared/cantor'
+import Cantor from '../shared/cantor'
 import { ValueError } from '../shared/errors'
 import Interval from '../models/interval'
 import Fraction from '../models/fraction'
 
 describe('Cantor Library', function() {
     describe('removeIntervals', function() {
-        let unit = new Interval(new Fraction(0, 1), new Fraction(1, 1))
 
         it('allows removal of one segment from the unit interval and returns two intervals', function() {
             // needs more cases
-            let res = removeIntervals(unit, 5, [2])
+            let res = removeIntervals(Interval.unit, 5, [2])
 
             expect(res.length).toEqual(2)
             expect(res[0].left.equals(new Fraction(0, 5))).toBeTruthy()
@@ -19,7 +19,7 @@ describe('Cantor Library', function() {
         })
 
         it('allows removal of two segments from the unit interval and returns the remaining three intervals', function() {
-            let res = removeIntervals(unit, 5, [2, 4])
+            let res = removeIntervals(Interval.unit, 5, [2, 4])
             expect(res.length).toEqual(3)
             expect(res[0].left.equals(new Fraction(0, 5))).toBeTruthy()
             expect(res[0].right.equals(new Fraction(1, 5))).toBeTruthy()
@@ -43,53 +43,53 @@ describe('Cantor Library', function() {
         })
 
         it('fails when attempting to remove the first interval', function(){
-            expect(() => removeIntervals(unit, 5, [1, 3])).toThrow(ValueError)
+            expect(() => removeIntervals(Interval.unit, 5, [1, 3])).toThrow(ValueError)
         })
 
         it('fails when attempting to remove the last interval', function(){
-            expect(() => removeIntervals(unit, 5, [3, 5])).toThrow(ValueError)
+            expect(() => removeIntervals(Interval.unit, 5, [3, 5])).toThrow(ValueError)
         })
     })
 
-    describe.only('Cantor iterations', function(){
+    describe('Cantor iterations', function(){
         describe('Standard Cantor: split into 3, remove middle', function(){
             it('Performs 1 iteration of standard Cantor', function() {
-                let res = cantor(3, [2], 1)
-                expect(res.length).toEqual(1)
-                expect(res[0].count).toEqual(2)
+                let res = new Cantor(3, [2], 1)
+                expect(res.numIter).toEqual(1)
+                expect(res.iterations[0].count).toEqual(2)
 
-                let first = res[0].intervals.all[0]
+                let first = res.iterations[0].intervals.all[0]
                 expect(first.left.equals(new Fraction(0,3))).toBeTruthy()
                 expect(first.right.equals(new Fraction(1,3))).toBeTruthy()
 
-                let second = res[0].intervals.all[1]
+                let second = res.iterations[0].intervals.all[1]
                 expect(second.left.equals(new Fraction(2,3))).toBeTruthy()
                 expect(second.right.equals(new Fraction(3,3))).toBeTruthy()
             })
 
             it('Performs 2 iterations of standard Cantor', function() {
-                let res = cantor(3, [2], 2)
-                expect(res.length).toEqual(2)
+                let res = new Cantor(3, [2], 2)
+                expect(res.numIter).toEqual(2)
+                expect(res.iterations[0].count).toEqual(2)
 
-                expect(res[0].count).toEqual(2)
-                let first = res[0].intervals.all[0]
+                let first = res.iterations[0].intervals.all[0]
                 expect(first.left.equals(new Fraction(0,3))).toBeTruthy()
                 expect(first.right.equals(new Fraction(1,3))).toBeTruthy()
-                let second = res[0].intervals.all[1]
+                let second = res.iterations[0].intervals.all[1]
                 expect(second.left.equals(new Fraction(2,3))).toBeTruthy()
                 expect(second.right.equals(new Fraction(3,3))).toBeTruthy()
 
-                expect(res[1].count).toEqual(4)
-                first = res[1].intervals.all[0]
+                expect(res.iterations[1].count).toEqual(4)
+                first = res.iterations[1].intervals.all[0]
                 expect(first.left.equals(new Fraction(0,9))).toBeTruthy()
                 expect(first.right.equals(new Fraction(1,9))).toBeTruthy()
-                second = res[1].intervals.all[1]
+                second = res.iterations[1].intervals.all[1]
                 expect(second.left.equals(new Fraction(2,9))).toBeTruthy()
                 expect(second.right.equals(new Fraction(3,9))).toBeTruthy()
-                let third = res[1].intervals.all[2]
+                let third = res.iterations[1].intervals.all[2]
                 expect(third.left.equals(new Fraction(6,9))).toBeTruthy()
                 expect(third.right.equals(new Fraction(7,9))).toBeTruthy()
-                let fourth = res[1].intervals.all[3]
+                let fourth = res.iterations[1].intervals.all[3]
                 expect(fourth.left.equals(new Fraction(8,9))).toBeTruthy()
                 expect(fourth.right.equals(new Fraction(9,9))).toBeTruthy()
             })
@@ -97,60 +97,59 @@ describe('Cantor Library', function() {
 
         describe('Non-standard Cantor', function() {
             it('Performs 1 iteration removing the 2nd and 4th segments of a unit interval divided into 5 segments', function(){
-                let res = cantor(5, [2, 4], 1)
-                expect(res.length).toEqual(1)
+                let res = new Cantor(5, [2, 4], 1)
+                expect(res.numIter).toEqual(1)
 
-                expect(res[0].count).toEqual(3)
+                expect(res.iterations[0].count).toEqual(3)
 
-                let first = res[0].intervals.all[0]
+                let first = res.iterations[0].intervals.all[0]
                 expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
                 expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
-                let second = res[0].intervals.all[1]
+                let second = res.iterations[0].intervals.all[1]
                 expect(second.left.equals(new Fraction(2,5))).toBeTruthy()
                 expect(second.right.equals(new Fraction(3,5))).toBeTruthy()
-                let third = res[0].intervals.all[2]
+                let third = res.iterations[0].intervals.all[2]
                 expect(third.left.equals(new Fraction(4,5))).toBeTruthy()
                 expect(third.right.equals(new Fraction(5,5))).toBeTruthy()
 
             })
 
             it('Performs 1 iteration removing the 2nd and 3rd segments of a unit interval divided into 5 segments', function() {
-                let res = cantor(5, [2, 3], 1)
-                expect(res.length).toEqual(1)
-                expect(res[0].count).toEqual(2)
-                let first = res[0].intervals.all[0]
+                let res = new Cantor(5, [2, 3], 1)
+                expect(res.numIter).toEqual(1)
+                expect(res.iterations[0].count).toEqual(2)
+                let first = res.iterations[0].intervals.all[0]
                 expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
                 expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
-                let second = res[0].intervals.all[1]
+                let second = res.iterations[0].intervals.all[1]
                 expect(second.left.equals(new Fraction(3,5))).toBeTruthy()
                 expect(second.right.equals(new Fraction(5,5))).toBeTruthy()
 
             })
 
             it('Performs 2 iterations removing the 2nd and 3rd segments of a unit interval dividided into 5', function(){
-                let res = cantor(5, [2, 3], 2)
+                let res = new Cantor(5, [2, 3], 2)
 
-                expect(res.length).toEqual(2)
-                expect(res[0].count).toEqual(2)
-                let first = res[0].intervals.all[0]
+                expect(res.numIter).toEqual(2)
+                expect(res.iterations[0].count).toEqual(2)
+                let first = res.iterations[0].intervals.all[0]
                 expect(first.left.equals(new Fraction(0,5))).toBeTruthy()
                 expect(first.right.equals(new Fraction(1,5))).toBeTruthy()
-                let second = res[0].intervals.all[1]
+                let second = res.iterations[0].intervals.all[1]
                 expect(second.left.equals(new Fraction(3,5))).toBeTruthy()
                 expect(second.right.equals(new Fraction(5,5))).toBeTruthy()
 
-                expect(res[1].count).toEqual(4)
-                first = res[1].intervals.all[0]
+                expect(res.iterations[1].count).toEqual(4)
+                first = res.iterations[1].intervals.all[0]
                 expect(first.left.equals(new Fraction(0,25))).toBeTruthy()
                 expect(first.right.equals(new Fraction(1,25))).toBeTruthy()
-                second = res[1].intervals.all[1]
+                second = res.iterations[1].intervals.all[1]
                 expect(second.left.equals(new Fraction(3,25))).toBeTruthy()
                 expect(second.right.equals(new Fraction(5, 25))).toBeTruthy()
-                let third = res[1].intervals.all[2]
+                let third = res.iterations[1].intervals.all[2]
                 expect(third.left.equals(new Fraction(15,25))).toBeTruthy()
-                expect(third.right.num).toEqual(17)
                 expect(third.right.equals(new Fraction(17,25))).toBeTruthy()
-                let fourth = res[1].intervals.all[3]
+                let fourth = res.iterations[1].intervals.all[3]
                 expect(fourth.left.equals(new Fraction(21,25))).toBeTruthy()
                 expect(fourth.right.equals(new Fraction(25,25))).toBeTruthy()
             })

--- a/src/test/interval.test.js
+++ b/src/test/interval.test.js
@@ -77,4 +77,9 @@ describe('Interval', function() {
             expect(result[1].right.equals(resultFracs[3])).toBeTruthy()
         })
     })
+
+    it.skip('fails if trying to subtract intervals which are not contained in the parent interval', function(){
+        // another each with various edge cases
+    })
+
 })

--- a/src/test/interval.test.js
+++ b/src/test/interval.test.js
@@ -4,12 +4,15 @@ import { IntervalRangeError } from '../shared/errors'
 
 describe('Interval', function() {
     describe('creating intervals', function(){
-        describe.each([
-            [ new Fraction(0,2), new Fraction(1,1), new Fraction(1,1) ],
-            [ new Fraction(0,5), new Fraction(3, 5), new Fraction(3, 5) ],
-            [ new Fraction(2,3), new Fraction(18,21), new Fraction(4, 21) ]
-        ])('when passed two appropriate fractions', (left, right, correctLen) => {
-            it(`Creates an Interval [${left.str}, ${right.str}] with length ${correctLen.str}`, () => {
+        describe.each`
+            interval_left   | interval_right    | correct_length
+            ${[0, 2]}       | ${[1, 1]}         | ${[1, 1]}
+            ${[0, 5]}       | ${[3, 5]}         | ${[3, 5]}
+            ${[2, 3]}       | ${[18, 21]}       | ${[4, 21]}
+        `('when passed two appropriate fractions', (interval_left, interval_right, correct_length) => {
+            let left = new Fraction(interval_left[0], interval_left[1])
+            let right = new Fraction(interval_right[0], interval_right[1])
+            it(`Creates an Interval [${left.str}, ${right.str}] with length ${correct_length.str}`, () => {
                 let testLen = new Interval(left, right).len.reduce()
                 expect(testLen.equals(correctLen)).toBeTruthy()
             })
@@ -38,11 +41,12 @@ describe('Interval', function() {
         expect( () => interval.right = new Fraction(2,3)).toThrow(TypeError)
     })
 
-    describe.each([
-        [ [1, 5],   [7, 10],    [2, 10],    [7, 10] ],
-        [ [2, 7],   [4, 5],     [10, 35],   [28, 35] ],
-        [ [3, 11],  [34, 90],   [270, 990], [374, 990] ]
-    ])('converts the endpoints to a common denominator', function(origLArr, origRArr, commonLArr, commonRArr) {
+    describe.each`
+        intervalL   | intervalR     | commonLArr    | commonRArr
+        ${[1, 5]}   | ${[7, 10]}    | ${[2, 10]}    | ${[7, 10]}
+        ${[2, 7]}   | ${[4, 5]}     | ${[10, 35]}   | ${[28, 35]}
+        ${[3, 11]}  | ${[34, 90]}   | ${[270, 990]} | ${[374, 990]}
+    `('converts the endpoints to a common denominator', function(intervalL, intervalR, commonLArr, commonRArr) {
         let origL = new Fraction(origLArr[0], origLArr[1])
         let origR = new Fraction(origRArr[0], origRArr[1])
         let commonL = new Fraction(commonLArr[0], commonLArr[1])
@@ -54,11 +58,32 @@ describe('Interval', function() {
             expect(convertedInterval.left.equals(commonL)).toBeTruthy()
             expect(convertedInterval.right.equals(commonR)).toBeTruthy()
         })
+    })
+
+        /*
+        // need to chang the test cases
+    describe.each`
+        intervalL   | intervalR     | newDen | specificLArr  | specificRArr
+        ${[1, 5]}   | ${[7, 10]}    | ${100} | ${[20, 100]}  | ${[70, 100]}
+        ${[2, 7]}   | ${[4, 5]}     | ${105} | ${[30, 105]}  | ${[84, 105]}
+        ${[3, 11]}  | ${[34, 90]}   | ${ xx} | ${[270, 990]} | ${[374, 990]}
+    `('converts the endpoints to a specified denominator', function(intervalL, intervalR, specificLArr, specificRArr) {
+        let origL = new Fraction(origLArr[0], origLArr[1])
+        let origR = new Fraction(origRArr[0], origRArr[1])
+        let commonL = new Fraction(commonLArr[0], commonLArr[1])
+        let commonR = new Fraction(commonRArr[0], commonRArr[1])
+        let originalInterval = new Interval(origL, origR)
+
+        it(`given Interval [${originalInterval.left.str}, ${originalInterval.right.str}], convert to [${commonL}, ${commonR}]`, () => {
+            let convertedInterval = originalInterval.commonDen()
+            expect(convertedInterval.left.equals(commonL)).toBeTruthy()
+            expect(convertedInterval.right.equals(commonR)).toBeTruthy()
+        })
+    })
 /*
         it.skip('convert endpoints to specified denominator')
         it.skip('errors if endpoints cannot be converted to given denominator')
         */
-    })
 
     describe.each([
         [ [[0, 5], [5, 5], [1, 5], [2, 5]], [[0, 5], [1, 5],[2, 5], [5, 5]] ],

--- a/src/test/interval.test.js
+++ b/src/test/interval.test.js
@@ -37,4 +37,44 @@ describe('Interval', function() {
         expect( () => interval.left = new Fraction(1,3)).toThrow(TypeError)
         expect( () => interval.right = new Fraction(2,3)).toThrow(TypeError)
     })
+
+    describe.each([
+        [ [1, 5],   [7, 10],    [2, 10],    [7, 10] ],
+        [ [2, 7],   [4, 5],     [10, 35],   [28, 35] ],
+        [ [3, 11],  [34, 90],   [270, 990], [374, 990] ]
+    ])('converts the endpoints to a common denominator', function(origLArr, origRArr, commonLArr, commonRArr) {
+        let origL = new Fraction(origLArr[0], origLArr[1])
+        let origR = new Fraction(origRArr[0], origRArr[1])
+        let commonL = new Fraction(commonLArr[0], commonLArr[1])
+        let commonR = new Fraction(commonRArr[0], commonRArr[1])
+        let originalInterval = new Interval(origL, origR)
+
+        it(`given Interval [${originalInterval.left.str}, ${originalInterval.right.str}], convert to [${commonL}, ${commonR}]`, () => {
+            let convertedInterval = originalInterval.commonDen()
+            expect(convertedInterval.left.equals(commonL)).toBeTruthy()
+            expect(convertedInterval.right.equals(commonR)).toBeTruthy()
+        })
+/*
+        it.skip('convert endpoints to specified denominator')
+        it.skip('errors if endpoints cannot be converted to given denominator')
+        */
+    })
+
+    describe.each([
+        [ [[0, 5], [5, 5], [1, 5], [2, 5]], [[0, 5], [1, 5],[2, 5], [5, 5]] ],
+        [ [[0, 1], [1, 1], [2, 4], [3, 4]], [[0, 4], [2, 4], [3, 4], [4, 4]] ],
+        [ [[1, 2], [7, 8], [11, 16], [6, 8]], [[8, 16], [11, 16], [12, 16], [14, 16]] ]
+    ])('subtracting a gap from an interval returns two subintervals', function(original, result) {
+        let origFracs = original.map(arr => new Fraction(arr[0], arr[1]))
+        let resultFracs = result.map(arr => new Fraction(arr[0], arr[1]))
+        let originalInterval = new Interval(origFracs[0], origFracs[1])
+        let toSubtract = new Interval(origFracs[2], origFracs[3])
+        it(`from ${originalInterval.str}, subtract ${toSubtract.str}`, () => {
+            let result = originalInterval.subtract(toSubtract)
+            expect(result[0].left.equals(resultFracs[0])).toBeTruthy()
+            expect(result[0].right.equals(resultFracs[1])).toBeTruthy()
+            expect(result[1].left.equals(resultFracs[2])).toBeTruthy()
+            expect(result[1].right.equals(resultFracs[3])).toBeTruthy()
+        })
+    })
 })

--- a/src/test/interval.test.js
+++ b/src/test/interval.test.js
@@ -9,7 +9,7 @@ describe('Interval', function() {
             ${[0, 2]}       | ${[1, 1]}         | ${[1, 1]}
             ${[0, 5]}       | ${[3, 5]}         | ${[3, 5]}
             ${[2, 3]}       | ${[18, 21]}       | ${[4, 21]}
-        `('when passed two appropriate fractions', ({intervalLeft, intervalRight, correctLength}) => {
+        `('when passed two appropriate fractions', ({ intervalLeft, intervalRight, correctLength }) => {
             let left = new Fraction(intervalLeft)
             let right = new Fraction(intervalRight)
             let correctLen = new Fraction(correctLength)
@@ -48,7 +48,7 @@ describe('Interval', function() {
         ${[1, 5]}   | ${[7, 10]}    | ${[2, 10]}    | ${[7, 10]}
         ${[2, 7]}   | ${[4, 5]}     | ${[10, 35]}   | ${[28, 35]}
         ${[3, 11]}  | ${[34, 90]}   | ${[270, 990]} | ${[374, 990]}
-    `('converts the endpoints to a common denominator', function({intervalL, intervalR, commonL, commonR}) {
+    `('converts the endpoints to a common denominator', function({ intervalL, intervalR, commonL, commonR }) {
         let originalInterval = new Interval(new Fraction(intervalL), new Fraction(intervalR))
         let convertedCorrect = new Interval(new Fraction(commonL), new Fraction(commonR))
 
@@ -66,7 +66,7 @@ describe('Interval', function() {
         ${[[1, 5], [7, 10]]}    | ${100} | ${[20, 100]}  | ${[70, 100]}
         ${[[2, 7], [4, 5]]}     | ${105} | ${[30, 105]}  | ${[84, 105]}
         ${[[1, 4], [1, 3]]}     | ${12}  | ${[3, 12]}    | ${[4, 12]}
-    `('converts the endpoints to a specified denominator', function({interval, newDen, specificLArr, specificRArr}) {
+    `('converts the endpoints to a specified denominator', function({ interval, newDen, specificLArr, specificRArr }) {
         let originalInterval = new Interval(interval)
         let commonL = new Fraction(specificLArr)
         let commonR = new Fraction(specificRArr)
@@ -83,7 +83,7 @@ describe('Interval', function() {
         ${[[1, 5], [7, 10]]}    | ${15}
         ${[[2, 7], [4, 5]]}     | ${28}
         ${[[1, 4], [1, 3]]}     | ${16}
-    `('errors if endpoints cannot be converted to the given denominator', function({interval, newDen}) {
+    `('errors if endpoints cannot be converted to the given denominator', function({ interval, newDen }) {
         it(`Interval ${interval} can't convert to denominator ${newDen}`, () => {
             expect( () => new Interval(interval).commonDen(newDen) ).toThrow(ValueError)
         })
@@ -95,7 +95,7 @@ describe('Interval', function() {
         ${[[0, 5], [5, 5]]} | ${[[1, 5], [2, 5]]}   | ${[[0, 5],[1, 5]]}    | ${[[2, 5], [5, 5]]}
         ${[[0, 1], [1, 1]]} | ${[[2, 4], [3, 4]]}   | ${[[0, 4], [2, 4]]}   | ${[[3, 4], [4, 4]]}
         ${[[1, 2], [7, 8]]} | ${[[11, 16], [6, 8]]} | ${[[8, 16], [11, 16]]}| ${[[12, 16], [14, 16]]}
-    `('subtracting a gap from an interval returns two subintervals', function({interval, toSubtract, resultL, resultR}) {
+    `('subtracting a gap from an interval returns two subintervals', function({ interval, toSubtract, resultL, resultR }) {
         interval = new Interval(interval)
         toSubtract = new Interval(toSubtract)
         resultL = new Interval(resultL)
@@ -115,7 +115,7 @@ describe('Interval', function() {
         ${[[1, 3], [2, 3]]}     | ${[[2, 7], [4, 9]]}
         ${[[1, 3], [190, 200]]} | ${[[16, 49], [191, 200]]}
         ${[[1, 2], [2, 3]]}     | ${[[1, 2], [7, 8]]}
-    `('fails if trying to subtract intervals which are not contained in the parent interval', function({interval, toSubtract}) {
+    `('fails if trying to subtract intervals which are not contained in the parent interval', function({ interval, toSubtract }) {
         interval = new Interval(interval)
         toSubtract = new Interval(toSubtract)
         it(`from ${interval.strMinimal}, fail to subtract ${toSubtract.strMinimal}`, () => {

--- a/src/test/interval_collection.test.js
+++ b/src/test/interval_collection.test.js
@@ -20,7 +20,7 @@ let sampleIntervalCommonDen = [
 ]
 
 
-let interval1 = new Interval(new Fraction (...sampleIntervals[0][0]), new Fraction(...sampleIntervals[0][1]))
+let interval1 = new Interval(new Fraction(...sampleIntervals[0][0]), new Fraction(...sampleIntervals[0][1]))
 let interval2 = new Interval(new Fraction(...sampleIntervals[0][2]), new Fraction(...sampleIntervals[0][3]))
 
 describe('IntervalArr', function() {
@@ -73,22 +73,19 @@ describe('IntervalArr', function() {
         it('concat_ does not allow adding multiple new intervals which do not appear sequentially after the existing intervals', function(){})
         let ep0 = new Fraction(0, 6)
         let ep1 = new Fraction(1, 6)
-        //let ep2 = new Fraction(2, 6)
         let ep3 = new Fraction(3, 6)
         let ep4 = new Fraction(4, 6)
         let ep5 = new Fraction(5, 6)
-        //let ep6 = new Fraction(6, 6)
 
         let interval0 = new Interval(ep0, ep1)
         let interval1 = new Interval(ep3, ep4)
         let interval2 = new Interval(ep4, ep5)
-        //let interval3 = new Interval(ep5, ep6)
 
         let intarr = new IntervalArr([interval2])
         expect( () => intarr.concat_([interval0, interval1])).toThrow(IntervalRangeError)
     })
 
-    describe.each(sampleIntervals)('smallestInterval', function(endpointLL, endpointLR, endpointRL, endpointRR, idx_){
+    describe.each(sampleIntervals)('converting all endpoints to a common denominator', function(endpointLL, endpointLR, endpointRL, endpointRR, idx_){
         let ll = new Fraction(endpointLL[0], endpointLL[1])
         let lr = new Fraction(endpointLR[0], endpointLR[1])
         let rl = new Fraction(endpointRL[0], endpointRL[1])
@@ -100,12 +97,7 @@ describe('IntervalArr', function() {
 
         let intarr = new IntervalArr([int1, int2])
 
-        it('it returns the smallest fractional unit among all endpoints', () => {
-            let comden = sampleIntervalCommonDen[idx][0][1]
-            expect(intarr.smallestInterval().equals(new Fraction(1, comden))).toBeTruthy()
-        })
-
-        it('it converts all endpoints to a common denominator, equal to the smallest fractional unit', () => {
+        it('it converts all endpoints to a common denominator', () => {
             let [commonDenL, commonDenR] = intarr.commonDen()
 
             let correctLL = sampleIntervalCommonDen[idx][0]

--- a/src/test/interval_collection.test.js
+++ b/src/test/interval_collection.test.js
@@ -73,7 +73,7 @@ describe('IntervalArr', function() {
         })
     })
 
-    sampleIntervals('converting all endpoints to a common denominator', function({index, interval1, interval2, interval1Common, interval2Common}){
+    sampleIntervals('converting all endpoints to a common denominator', function({ interval1, interval2, interval1Common, interval2Common }){
 
         it('it converts all endpoints to a common denominator', () => {
             let testArr = new IntervalArr([ new Interval(interval1), new Interval(interval2) ]).commonDen()
@@ -111,7 +111,7 @@ describe('IntervalCollection', function() {
         })
     })
 
-    sampleIntervals('line segment and gap intervals', function({index, interval1, interval2}){
+    sampleIntervals('line segment and gap intervals', function({ index, interval1, interval2 }){
         let int1 = new Interval(interval1)
         let int2 = new Interval(interval2)
 


### PR DESCRIPTION
Fractions
- allow Fractions to be created by passing in an array of two valid numbers
- implement comparison operator greaterThan for Fractions
- multiplication for Fractions

Intervals
- allow Intervals to be created by passing in an array of two-element sub-arrays containing the fractional representation of the left and right endpoints
- calculate common denominator for Intervals, including passing optional desired denominator
- subtract/add for Intervals

IntervalCollection
- calculate a common denominator for the entire collection
- implement forEach to ease iteration through intervals

new Cantor class added
- Closes #16, #18
- calculate Cantor-like sets with variable inputs for number of segments to remove
- refactored to make the functionality more flexible for future explorations

Existing tests were fixed and some new ones added. More coverage will be added in #17