### PR TITLE
22 remove unused code

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "jest": {
       "coveragePathIgnorePatterns" : [
           "./src/App.js",
-          "./src/index.js"
+          "./src/index.js",
+          "./src/shared/errors.js"
       ]
   }
 }

--- a/src/models/cantor.js
+++ b/src/models/cantor.js
@@ -99,4 +99,5 @@ function convertSegmentsToIntervals(interval, segmentLength, segNum){
 
 if(process.env['NODE_ENV'] === 'test') {
     exports.removeIntervals = removeIntervals
+    exports.convertSegmentsToIntervals = convertSegmentsToIntervals
 }

--- a/src/models/cantor.js
+++ b/src/models/cantor.js
@@ -1,16 +1,24 @@
 import Fraction from './fraction'
 import Interval from './interval'
 import IntervalCollection from './interval_collection'
-import { ValueError } from '../shared/errors'
+import { ValueError, ArgumentError } from '../shared/errors'
+import { type, checkArrContents } from '../shared/utils'
 
 // in case I ever decide to look into alternating the segments between iterations, I removed most of the utility functions from the class to keep the flexibility that was lost when everything was tied to an instance
 
 // returns an array of IntervalCollections, where each IntervalCollection is one iteration of Cantor
 export default class Cantor {
-    constructor( numSegments = 3, toRemove = [2], numIter = 1 ){
-        if(toRemove.includes(1) || toRemove.includes(numSegments)){
+    constructor(numSegments, toRemove, numIter){
+        if(
+            type(numSegments) !== 'number'
+            || !( type(toRemove) === 'Array' && checkArrContents(toRemove, 'number') )
+            || type(numIter) !== 'number'
+        ){
+            throw new ArgumentError('For new Cantor, must pass the number of segments to divide the interval, an array of the segment numbers to be removed, and the number of Cantor iterations to perform.')
+        } else if(toRemove.includes(1) || toRemove.includes(numSegments)){
             throw new ValueError(`Cannot remove the first or last segment in an interval: you asked to remove ${toRemove}`)
         }
+
         toRemove = toRemove.sort( (a,b) => a-b )
 
         this.numSegments = numSegments
@@ -97,6 +105,7 @@ function convertSegmentsToIntervals(interval, segmentLength, segNum){
     return intervals
 }
 
+/* istanbul ignore next */
 if(process.env['NODE_ENV'] === 'test') {
     exports.removeIntervals = removeIntervals
     exports.convertSegmentsToIntervals = convertSegmentsToIntervals

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -99,9 +99,7 @@ class Fraction {
     }
 
     add(rhs) {
-        if(type(rhs) === 'number'){
-            return new Fraction(this.num + rhs, this.den)
-        } else if(type(rhs) === 'Fraction'){
+        if(type(rhs) === 'Fraction'){
             let [ leftHS, rightHS ] = this.commonDen(rhs)
             let numerator = leftHS.num + rightHS.num
             if (numerator > leftHS.den){

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -1,5 +1,5 @@
 import { lcm, type, checkArrContents } from '../shared/utils'
-import { FracError } from '../shared/errors'
+import { ValueError, FracError } from '../shared/errors'
 
 class Fraction {
     #numerator = 1
@@ -12,22 +12,21 @@ class Fraction {
             ||( arguments.length === 1
                 && type(numeratorArg) === 'Array'
                 && numeratorArg.length === 0 )
-            )
-        {
+        ){
             this.#numerator = 1
             this.#denominator = 1
             return this
         } else if (arguments.length === 1
             && type(numeratorArg) === 'Array'
             && numeratorArg.length === 2
-            && checkArrContents(numeratorArg, 'number'))
-        {
+            && checkArrContents(numeratorArg, 'number')
+        ){
             numerator = numeratorArg[0]
             denominator = numeratorArg[1]
         } else if (arguments.length === 2
             && type(numeratorArg) === 'number'
-            && type(denominatorArg === 'number'))
-        {
+            && type(denominatorArg === 'number')
+        ){
             numerator = numeratorArg
             denominator = denominatorArg
         } else {
@@ -60,7 +59,7 @@ class Fraction {
 
     commonDen(otherFrac){
         if (type(otherFrac) !== 'Fraction'){
-            throw new TypeError(`Must pass one fraction to Fraction.commonDen: you passed in ${type(otherFrac)}`)
+            throw new ValueError(`Must pass one fraction to Fraction.commonDen: you passed in ${type(otherFrac)}`)
         }
         const common = lcm([this.den, otherFrac.den])
         let numA = (this.num * (common/this.den))
@@ -89,7 +88,7 @@ class Fraction {
     // subtract the passed in fraction from and return a new Fraction
     subtract(rhs) {
         if (type(rhs) !== 'Fraction'){
-            throw new TypeError(`Must pass only Fraction argument to subtract: you passed in ${type(rhs)}`)
+            throw new ValueError(`Must pass only Fraction argument to subtract: you passed in ${type(rhs)}`)
         }
         let [ leftHS, rightHS ] = this.commonDen(rhs)
         let numerator = leftHS.num - rightHS.num

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -9,9 +9,10 @@ class Fraction {
         let numerator, denominator
 
         if(arguments.length === 0
-            ||(arguments.length === 1
+            ||( arguments.length === 1
                 && type(numeratorArg) === 'Array'
-                && numeratorArg.length === 0))
+                && numeratorArg.length === 0 )
+            )
         {
             this.#numerator = 1
             this.#denominator = 1
@@ -48,15 +49,6 @@ class Fraction {
     }
 
     // given 2 fractions, convert them to have a common denominator and return them in a 2 item Array
-    static commonDen(fracA, fracB){
-        if (type(fracA) !== 'Fraction' || type(fracB) !== 'Fraction'){
-            throw new TypeError(`Must pass two fractions as separate arguments to Fraction.commonDen: you passed in ${type(fracA)} and ${type(fracB)}`)
-        }
-        const common = lcm([fracA.den, fracB.den])
-        let numA = (fracA.num * (common/fracA.den))
-        let numB = (fracB.num * (common/fracB.den))
-        return [ new Fraction(numA, common), new Fraction(numB, common) ]
-    }
 
     get num() {
         return this.#numerator
@@ -64,6 +56,16 @@ class Fraction {
 
     get den() {
         return this.#denominator
+    }
+
+    commonDen(otherFrac){
+        if (type(otherFrac) !== 'Fraction'){
+            throw new TypeError(`Must pass one fraction to Fraction.commonDen: you passed in ${type(otherFrac)}`)
+        }
+        const common = lcm([this.den, otherFrac.den])
+        let numA = (this.num * (common/this.den))
+        let numB = (otherFrac.num * (common/otherFrac.den))
+        return [ new Fraction(numA, common), new Fraction(numB, common) ]
     }
 
     reduce() {
@@ -89,7 +91,7 @@ class Fraction {
         if (type(rhs) !== 'Fraction'){
             throw new TypeError(`Must pass only Fraction argument to subtract: you passed in ${type(rhs)}`)
         }
-        let [ leftHS, rightHS ] = Fraction.commonDen(this, rhs)
+        let [ leftHS, rightHS ] = this.commonDen(rhs)
         let numerator = leftHS.num - rightHS.num
         if(numerator < 0){
             throw new FracError.NoNegativeFractions(`Difference of ${this.str} and ${rhs.str} would be less than 0.`)
@@ -101,7 +103,7 @@ class Fraction {
         if(type(rhs) === 'number'){
             return new Fraction(this.num + rhs, this.den)
         } else if(type(rhs) === 'Fraction'){
-            let [ leftHS, rightHS ] = Fraction.commonDen(this, rhs)
+            let [ leftHS, rightHS ] = this.commonDen(rhs)
             let numerator = leftHS.num + rightHS.num
             if (numerator > leftHS.den){
                 throw new FracError.FractionTooLarge(`Sum of ${this.str} and ${rhs.str} would be greater than 1.`)
@@ -113,17 +115,17 @@ class Fraction {
     }
 
     lessThan(rhs){
-        let [fracA, fracB] = Fraction.commonDen(this, rhs)
+        let [fracA, fracB] = this.commonDen(rhs)
         return (fracA.num < fracB.num)
     }
 
     greaterThan(rhs){
-        let [fracA, fracB] = Fraction.commonDen(this, rhs)
+        let [fracA, fracB] = this.commonDen(rhs)
         return (fracA.num > fracB.num)
     }
 
     equals(rhs){
-        let [fracA, fracB] = Fraction.commonDen(this, rhs)
+        let [fracA, fracB] = this.commonDen(rhs)
         return (fracA.num === fracB.num)
     }
 

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -1,5 +1,5 @@
 import { lcm, type, checkArrContents } from '../shared/utils'
-import { ValueError, FracError } from '../shared/errors'
+import { FracError, ArgumentError } from '../shared/errors'
 
 class Fraction {
     #numerator = 1
@@ -59,7 +59,7 @@ class Fraction {
 
     commonDen(otherFrac){
         if (type(otherFrac) !== 'Fraction'){
-            throw new ValueError(`Must pass one fraction to Fraction.commonDen: you passed in ${type(otherFrac)}`)
+            throw new ArgumentError(`Must pass one fraction to Fraction.commonDen: you passed in ${type(otherFrac)}`)
         }
         const common = lcm([this.den, otherFrac.den])
         let numA = (this.num * (common/this.den))
@@ -88,7 +88,7 @@ class Fraction {
     // subtract the passed in fraction from and return a new Fraction
     subtract(rhs) {
         if (type(rhs) !== 'Fraction'){
-            throw new ValueError(`Must pass only Fraction argument to subtract: you passed in ${type(rhs)}`)
+            throw new ArgumentError(`Must pass only Fraction argument to subtract: you passed in ${type(rhs)}`)
         }
         let [ leftHS, rightHS ] = this.commonDen(rhs)
         let numerator = leftHS.num - rightHS.num
@@ -107,7 +107,7 @@ class Fraction {
             }
             return new Fraction(numerator, leftHS.den)
         } else {
-            throw new TypeError(`Must pass only Fraction argument to add: you passed in ${type(rhs)}`)
+            throw new ArgumentError(`Must pass only Fraction argument to add: you passed in ${type(rhs)}`)
         }
     }
 
@@ -132,7 +132,7 @@ class Fraction {
         } else if (type(rhs) === 'Fraction'){
             return new Fraction(this.num * rhs.num, this.den * rhs.den)
         } else {
-            throw new TypeError('Can only multiply fractions by a scalar or another fraction.')
+            throw new ArgumentError('Can only multiply fractions by a scalar or another fraction.')
         }
     }
 }

--- a/src/models/fraction.js
+++ b/src/models/fraction.js
@@ -30,7 +30,7 @@ class Fraction {
             numerator = numeratorArg
             denominator = denominatorArg
         } else {
-            throw new TypeError(`Must send either an Array of two numbers, or two numbers to new Fraction: you passed ${numeratorArg}, ${denominatorArg}`)
+            throw new ArgumentError(`Must send either an Array of two numbers, or two numbers to new Fraction: you passed ${numeratorArg}, ${denominatorArg}`)
         }
 
         if(denominator === 0){

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -84,6 +84,10 @@ class Interval {
     equals(interval) {
         return(this.left.equals(interval.left) && this.right.equals(interval.right))
     }
+
+    lessThan(interval){
+        return(this.right.lessThan(interval.left))
+    }
 }
 
 Interval.unit = new Interval( new Fraction(0, 1), new Fraction(1, 1) )

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -81,16 +81,8 @@ class Interval {
         return remainingSegments
     }
 
-    // returns a new interval representing the sum of the two sequential intervals
-    add(intToAdd) {
-        let commonDenominator = lcm([this.left.den, this.right.den, intToAdd.left.den, intToAdd.right.den])
-        let intCommon = this.commonDen(commonDenominator)
-        let addCommon = intToAdd.commonDen(commonDenominator)
-        if(intCommon.right.num + 1 !== addCommon.left.num){
-            throw new IntervalRangeError(`The given interval, ${intToAdd.str}, is not sequrntial to this interval, ${this.str}.`)
-        }
-
-        return new Interval(intCommon.left, addCommon.right)
+    equals(interval) {
+        return(this.left.equals(interval.left) && this.right.equals(interval.right))
     }
 }
 

--- a/src/models/interval.js
+++ b/src/models/interval.js
@@ -1,5 +1,5 @@
 import { type, lcm, checkArrContents } from '../shared/utils'
-import { IntervalRangeError, ValueError } from '../shared/errors'
+import { IntervalRangeError, ArgumentError, ValueError } from '../shared/errors'
 import Fraction from './fraction'
 
 class Interval {
@@ -22,7 +22,7 @@ class Interval {
             tempLeft = leftEndpointArg
             tempRight = rightEndpointArg
         } else {
-            throw new TypeError(`Interval constructor requires 1) two fractions or 2) an array containing two sub-arrays representing the two Fractions: you passed ${leftEndpointArg}, ${rightEndpointArg}`)
+            throw new ArgumentError(`Interval constructor requires 1) two fractions or 2) an array containing two sub-arrays representing the two Fractions: you passed ${leftEndpointArg}, ${rightEndpointArg}`)
         }
 
         if (tempRight.lessThan(tempLeft)) {

--- a/src/models/interval_collection.js
+++ b/src/models/interval_collection.js
@@ -1,7 +1,7 @@
 import Fraction from './fraction'
 import Interval from './interval'
-import { IntervalRangeError, ValueError, IntervalSequenceError } from '../shared/errors'
-import { lcm, type, checkArrContents } from '../shared/utils'
+import { IntervalSequenceError } from '../shared/errors'
+import { lcm, checkArrContents } from '../shared/utils'
 
 function checkSequence(intervalsArr){
     intervalsArr.forEach((interval, idx, arr) => {

--- a/src/models/interval_collection.js
+++ b/src/models/interval_collection.js
@@ -1,55 +1,72 @@
 import Fraction from './fraction'
 import Interval from './interval'
-import { IntervalRangeError, ValueError } from '../shared/errors'
+import { IntervalRangeError, ValueError, IntervalSequenceError } from '../shared/errors'
 import { lcm, type, checkArrContents } from '../shared/utils'
 
-class IntervalArr {
+function checkSequence(intervalsArr){
+    intervalsArr.forEach((interval, idx, arr) => {
+        if( (idx !== arr.length - 1) && !(interval.lessThan(arr[idx + 1])) ){
+            throw new IntervalSequenceError(`When building an IntervalCollection, the interval ${interval.str} cannot be followed by ${arr[idx+1].str}`)
+        }
+    })
+}
 
-    constructor( intervalArrArg ) {
-        try {
-            checkArrContents(intervalArrArg, 'Interval')
-        } catch (e) {
-            throw e
+// input: array of one or more Line Segments
+class IntervalCollection {
+    #myIntervals = []
+
+    // pass the gaps or intervals arr (or any arr of intervals)
+    constructor( intervalsArr ){
+        if(intervalsArr !== undefined){
+            checkArrContents(intervalsArr, 'Interval')
+            checkSequence(intervalsArr)
+            this.#myIntervals = intervalsArr
         }
 
-        this.collection = intervalArrArg
+        this.count = this.#myIntervals.length
+        this.str = `{IntervalCollection - count: ${this.count}, tot len: ${this.len.str} collection: ${this.#myIntervals.map(interval => interval.str)}}`
     }
 
-    get all() {
-        return this.collection
+    get intervals() {
+        return [...this.#myIntervals]
     }
 
-    push_(interval){
-        if(type(interval) !== 'Interval'){
-            debugger
-            throw new ValueError(`Can only add Intervals, you passed a ${type(interval)}.`)
-        } else if ( this.collection.length > 0 && interval.left.lessThan(this.collection[this.collection.length - 1].right) ) {
-            throw new IntervalRangeError(`intervals must appear in order from left to right, starting at a minimum 0/1 and ending at a maximum of 1/1. The last endpoint of the interval collection is ${this.collection[this.collection.length - 1].right.str} and you attempted to append an interval starting at ${interval.left.str}, which is not allowed.`)
+    // total length of all intervals in collection
+    get len() {
+        return this.intervals.reduce((acc, curr) => acc.add(curr.len), new Fraction(0,1))
+    }
+
+    // total length of all gaps in this collection
+    get gapLen() {
+        return (Fraction.unit).subtract(this.len)
+    }
+
+    get gaps() {
+        const g = []
+        for ( let i = 0; i < this.count - 1; i++) {
+            g.push(new Interval( this.intervals[i].right, this.intervals[i+1].left))
         }
-        this.collection.push(interval)
+        return g
     }
 
-    concat_(intervalArr) {
-        checkArrContents(intervalArr, 'Interval')
-        try {
-            intervalArr.forEach( inter => this.push_(inter) )
-        } catch(e) {
-            throw e
+    forEach(cb) {
+        for(let i = 0; i < this.count; i+=1){
+            cb(this.#myIntervals[i], i, this)
         }
     }
 
-    // convert all fractions to use a common denominator - used for display purposes
+    // convert all endpoints in the interval to a common denominator - used for display
     commonDen() {
         let denominators = []
 
-        this.collection.forEach( interval => {
+        this.intervals.forEach( interval => {
             denominators.push(interval.left.den)
             denominators.push(interval.right.den)
         })
 
         let smallestDen = lcm(denominators)
 
-        let common = this.collection.map( interval => {
+        let common = this.intervals.map( interval => {
             const Lmultiple     = smallestDen / interval.left.den
             const Rmultiple     = smallestDen / interval.right.den
             const tempSeg = new Interval(
@@ -62,56 +79,11 @@ class IntervalArr {
     }
 }
 
-// input: array of one or more Line Segments
-class IntervalCollection {
-    #myIntervals
-
-    // pass the gaps or intervals arr (or any arr of intervals)
-    constructor( intervalsArrArg ){
-        checkArrContents(intervalsArrArg, 'Interval')
-
-        this.#myIntervals = new IntervalArr(intervalsArrArg)
-        // count of intervals in the collection
-        this.count = this.#myIntervals.collection.length
-        this.str = `{IntervalCollection - count: ${this.count}, collection: ${this.intervals.all.map(interval => interval.str)}}`
-    }
-
-    get intervals() {
-        return this.#myIntervals
-    }
-
-    // total length of all intervals in collection
-    get len() {
-        return this.intervals.all.reduce((acc, curr) => acc.add(curr.len), new Fraction(0,1))
-    }
-
-    // total length of all gaps in this collection
-    get gapLen() {
-        return (Fraction.unit).subtract(this.len)
-    }
-
-    get gaps() {
-        const g = new IntervalArr([])
-        for ( let i = 0; i < this.count - 1; i++) {
-            g.push_(new Interval( this.intervals.all[i].right, this.intervals.all[i+1].left))
-        }
-        return g
-    }
-
-    concat_(intervalArr) {
-        this.#myIntervals.all.concat_(intervalArr)
-    }
-
-    forEach(cb) {
-        for(let i = 0; i < this.count; i+=1){
-            cb(this.#myIntervals.all[i], i, this)
-        }
-    }
-}
+IntervalCollection.prototype.toString = function icToString() { return this.str }
 
 export default IntervalCollection
 
-/* istanbul ignore if */
+/* istanbul ignore next */
 if(process.env['NODE_ENV'] === 'test') {
-    exports.IntervalArr = IntervalArr
+    exports.checkSequence = checkSequence
 }

--- a/src/models/interval_collection.js
+++ b/src/models/interval_collection.js
@@ -1,6 +1,6 @@
 import Fraction from './fraction'
 import Interval from './interval'
-import { IntervalRangeError } from '../shared/errors'
+import { IntervalRangeError, ValueError } from '../shared/errors'
 import { lcm, type, checkArrContents } from '../shared/utils'
 
 class IntervalArr {
@@ -20,8 +20,9 @@ class IntervalArr {
     }
 
     push_(interval){
-        if(!type(interval) === 'Interval'){
-            throw new TypeError(`Can only add Intervals, you passed a ${type(interval)}.`)
+        if(type(interval) !== 'Interval'){
+            debugger
+            throw new ValueError(`Can only add Intervals, you passed a ${type(interval)}.`)
         } else if ( this.collection.length > 0 && interval.left.lessThan(this.collection[this.collection.length - 1].right) ) {
             throw new IntervalRangeError(`intervals must appear in order from left to right, starting at a minimum 0/1 and ending at a maximum of 1/1. The last endpoint of the interval collection is ${this.collection[this.collection.length - 1].right.str} and you attempted to append an interval starting at ${interval.left.str}, which is not allowed.`)
         }
@@ -67,11 +68,7 @@ class IntervalCollection {
 
     // pass the gaps or intervals arr (or any arr of intervals)
     constructor( intervalsArrArg ){
-        try {
-            checkArrContents(intervalsArrArg, 'Interval')
-        } catch(e) {
-            throw e
-        }
+        checkArrContents(intervalsArrArg, 'Interval')
 
         this.#myIntervals = new IntervalArr(intervalsArrArg)
         // count of intervals in the collection
@@ -114,6 +111,7 @@ class IntervalCollection {
 
 export default IntervalCollection
 
+/* istanbul ignore if */
 if(process.env['NODE_ENV'] === 'test') {
     exports.IntervalArr = IntervalArr
 }

--- a/src/shared/errors.js
+++ b/src/shared/errors.js
@@ -58,6 +58,18 @@ export class ValueError extends Error {
     }
 }
 
+export class IntervalSequenceError extends Error{
+    constructor(message, options) {
+        super(message, options)
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, ValueError)
+        }
+        this.name = 'IntervalSequenceError'
+        this.message = message ? message : 'An invalid action was performed with Intervals.'
+    }
+}
+
 export const FracError = {
     ZeroDenominator,
     NoNegativeFractions,

--- a/src/shared/errors.js
+++ b/src/shared/errors.js
@@ -3,9 +3,9 @@ class ZeroDenominator extends Error {
         super(message, options)
 
         if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, ZeroDenominator)
+            Error.captureStackTrace(this, this.constructor.name)
         }
-        this.name = 'ZeroDenominator'
+        this.name = this.constructor.name
         this.message = message ? message : 'Cannot have fractions with zero in the denominator'
     }
 }
@@ -15,9 +15,9 @@ class NoNegativeFractions extends Error {
         super(message, options)
 
         if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, NoNegativeFractions)
+            Error.captureStackTrace(this, this.constructor.name)
         }
-        this.name = 'NoNegativeFractions'
+        this.name = this.constructor.name
         this.message = message ? message : 'Cannot support negative fractions'
     }
 }
@@ -27,9 +27,9 @@ class FractionTooLarge extends Error {
         super(message, options)
 
         if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, FractionTooLarge)
+            Error.captureStackTrace(this, this.constructor.name)
         }
-        this.name = 'FractionTooLarge'
+        this.name = this.constructor.name
         this.message = message ? message : 'Cannot support fractions greater than 1'
     }
 }
@@ -39,9 +39,9 @@ export class IntervalRangeError extends Error {
         super(message, options)
 
         if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, IntervalRangeError)
+            Error.captureStackTrace(this, this.constructor.name)
         }
-        this.name = 'IntervalRangeError'
+        this.name = this.constructor.name
         this.message = message ? message : 'An invalid value was passed'
     }
 }
@@ -51,9 +51,9 @@ export class ValueError extends Error {
         super(message, options)
 
         if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, ValueError)
+            Error.captureStackTrace(this, this.constructor.name)
         }
-        this.name = 'ValueError'
+        this.name = this.constructor.name
         this.message = message ? message : 'An invalid value was passed as an argument'
     }
 }
@@ -63,9 +63,21 @@ export class IntervalSequenceError extends Error{
         super(message, options)
 
         if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, ValueError)
+            Error.captureStackTrace(this, this.constructor.name)
         }
-        this.name = 'IntervalSequenceError'
+        this.name = this.constructor.name
+        this.message = message ? message : 'An invalid action was performed with Intervals.'
+    }
+}
+
+export class ArgumentError extends Error {
+    constructor(message, options) {
+        super(message, options)
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor.name)
+        }
+        this.name = this.constructor.name
         this.message = message ? message : 'An invalid action was performed with Intervals.'
     }
 }

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -39,33 +39,38 @@ function type(value) {
     // Symbol.toStringTag often specifies the "display name" of the
     // object's class. It's used in Object.prototype.toString().
     const tag = value[Symbol.toStringTag]
+    /* istanbul ignore if */
     if (typeof tag === 'string') {
         return tag
     }
 
     // If it's a function whose source code starts with the "class" keyword
+    /* istanbul ignore if */
     if (
         baseType === 'function' &&
         Function.prototype.toString.call(value).startsWith('class')
-    ) {
+    ){
         return 'class'
     }
 
     // The name of the constructor; for example `Array`, `GeneratorFunction`,
     // `Number`, `String`, `Boolean` or `MyCustomClass`
+
     const className = value.constructor.name
+    /* istanbul ignore if */
     if (typeof className === 'string' && className !== '') {
         return className
     }
 
     // At this point there's no robust way to get the type of value,
     // so we use the base implementation.
+    /* istanbul ignore next */
     return baseType
 }
 
 function checkArrContents(arr, typeStr){
     if( !Array.isArray(arr) ){
-        throw new TypeError(`Must pass an Array of type ${typeStr}`)
+        throw new TypeError(`Must pass an Array of type ${typeStr}: you passed ${type(arr)} with value ${arr}`)
     }
     let not_intervals = arr.filter( item => !(type(item) === typeStr))
     if(not_intervals.length !== 0){
@@ -74,6 +79,7 @@ function checkArrContents(arr, typeStr){
     return true
 }
 
+/* istanbul ignore if */
 if (process.env['NODE_ENV'] === 'test') {
     exports.gcd = gcd
 }

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -1,4 +1,4 @@
-import { ValueError } from './errors'
+import { ValueError, ArgumentError } from './errors'
 
 function gcd(a, b){
     return b === 0 ? a : gcd(b, a % b)
@@ -70,11 +70,11 @@ function type(value) {
 
 function checkArrContents(arr, typeStr){
     if( !Array.isArray(arr) ){
-        throw new TypeError(`Must pass an Array of type ${typeStr}: you passed ${type(arr)} with value ${arr}`)
+        throw new ArgumentError(`Must pass an Array of type ${typeStr}: you passed ${type(arr)} with value ${arr}`)
     }
     let not_intervals = arr.filter( item => !(type(item) === typeStr))
     if(not_intervals.length !== 0){
-        throw new TypeError(`Must pass an Array of ${typeStr}: inside the Array, you passed ${JSON.stringify(not_intervals)}`)
+        throw new ArgumentError(`Must pass an Array of ${typeStr}: inside the Array, you passed ${JSON.stringify(not_intervals)}`)
     }
     return true
 }

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -1,6 +1,6 @@
 import { removeIntervals, convertSegmentsToIntervals } from '../models/cantor'
 import Cantor from '../models/cantor'
-import { ValueError } from '../shared/errors'
+import { ArgumentError, ValueError } from '../shared/errors'
 import Interval from '../models/interval'
 import Fraction from '../models/fraction'
 
@@ -167,6 +167,21 @@ describe('Cantor Library', function() {
 
 
     describe('Cantor iterations', function(){
+        it('New fails when asked to remove the first segment in a divided interval', function(){
+            expect( () => new Cantor(3, [1, 2], 1) ).toThrow(ValueError)
+        })
+
+        it('New fails when asked to remove the last segment in a divided interval', function(){
+            expect( () => new Cantor(4, [2, 4], 1) ).toThrow(ValueError)
+        })
+
+        it('New fails if passed incorrect parameters', function(){
+            expect( () => new Cantor([4], [2], 1) ).toThrow(ArgumentError)
+            expect( () => new Cantor(4, 2, 1) ).toThrow(ArgumentError)
+            expect( () => new Cantor(4, [2], null) ).toThrow(ArgumentError)
+
+        })
+
         describe('Standard Cantor: split into 3, remove middle', function(){
             describe('Performs 1 iteration of standard Cantor', function() {
                 let res = new Cantor(3, [2], 1)

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -1,13 +1,99 @@
-import { removeIntervals } from '../models/cantor'
+import { removeIntervals, convertSegmentsToIntervals } from '../models/cantor'
 import Cantor from '../models/cantor'
 import { ValueError } from '../shared/errors'
 import Interval from '../models/interval'
 import Fraction from '../models/fraction'
 
 describe('Cantor Library', function() {
-    describe('removeIntervals', function() {
+    describe('Convert segment numbers to intervals', function(){
+        // standard Cantor first iter
+        it('Given the unit Interval, segment length of 1/3, and segment [2], return the interval [1/3, 2/3]', function(){
+            let gaps = convertSegmentsToIntervals(Interval.unit, new Fraction(1, 3), [2])
+            let correct = new Interval([[1, 3], [2, 3]])
+            expect(gaps[0].equals(correct)).toBeTruthy()
+        })
 
-        describe('one centered gap of size 1/5, taking [2] from a 5-segment line', function() {
+        // Cantor-like with 5 segments, removing center, first iter
+        it('given the unit interval, segment length 1/5, and segment [3], return one interval [2/5, 3/5]', function(){
+            let gaps = convertSegmentsToIntervals(
+                Interval.unit,
+                new Fraction(1, 5),
+                [3]
+            )
+            let correct = new Interval([[2,5],[3,5]])
+
+            expect(gaps[0].equals(correct)).toBeTruthy()
+        })
+
+        // still symmetrical, starting with Unit, removing 2nd and 4th segments out of 5, first iter
+        it('given the unit Interval, segment length of 1/5, and segments [2, 4], return two intervals [1/5, 2/5], [3/5, 4/5]', function() {
+            let gaps = convertSegmentsToIntervals(
+                Interval.unit,
+                new Fraction(1, 5),
+                [2, 4])
+            let correct = [
+                new Interval([[1,5], [2,5]]),
+                new Interval([[3,5], [4,5]])
+            ]
+
+            gaps.forEach( (gap, idx) => {
+                expect(gap.equals(correct[idx])).toBeTruthy()
+            })
+        })
+
+        // still symmetrical, starting with a first iteration interval, removing 2nd and 4th segments out of 5, second iter
+        it('given the Interval [2/5, 3/5], segment length 1/25, and segments [2, 4], return two intervals of [11/25, 12/25], [13/25, 14/25]', function(){
+            let gaps = convertSegmentsToIntervals(
+                new Interval([[2,5],[3,5]]),
+                new Fraction(1, 25),
+                [2, 4]
+            )
+            let correct = [
+                new Interval([[11,25], [12,25]]),
+                new Interval([[13,25], [14,25]])
+            ]
+
+            gaps.forEach( (gap, idx) => {
+                expect(gap.equals(correct[idx])).toBeTruthy()
+            })
+        })
+
+        // asymmetrical with gap of size greater than 1 segment, 5-segmented line removing [2, 3] to produce one interval
+        it('given the unit Interval, segment length 1/5, and segments [2, 3], return the interval [1/5, 3/5]', function(){
+            let gaps = convertSegmentsToIntervals(
+                Interval.unit,
+                new Fraction(1, 5),
+                [2, 3]
+            )
+            let correct = [
+                new Interval([[1,5], [3,5]])
+            ]
+
+            expect(gaps[0].equals(correct[0])).toBeTruthy()
+        })
+
+        // asymmetrical removing gaps of different sizes from 7-segment line
+        it('given Interval [3/7, 4/7], remove gaps [3, 5, 6] from a 7-segmented interval to return 2 intervals', function(){
+
+            let gaps = convertSegmentsToIntervals(
+                new Interval([[3,7],[4,7]]),
+                new Fraction(1, 49),
+                [3, 5, 6]
+            )
+            let correct = [
+                new Interval([[23,49], [24,49]]),
+                new Interval([[25,49], [27,49]])
+            ]
+
+            gaps.forEach( (gap, idx) => {
+                expect(gap.equals(correct[idx])).toBeTruthy()
+            })
+        })
+
+    })
+
+    describe('removeIntervals', function() {
+        describe('one uncentered gap of size 1/5, taking [2] from a 5-segment line', function() {
             let res = removeIntervals(Interval.unit, 5, [2])
 
             it('produces 2 intervals', function(){
@@ -78,6 +164,7 @@ describe('Cantor Library', function() {
             expect(() => removeIntervals(Interval.unit, 5, [3, 5])).toThrow(ValueError)
         })
     })
+
 
     describe('Cantor iterations', function(){
         describe('Standard Cantor: split into 3, remove middle', function(){

--- a/src/test/cantor.test.js
+++ b/src/test/cantor.test.js
@@ -182,7 +182,7 @@ describe('Cantor Library', function() {
                     ${0}        | ${1}  | ${[2, 3]}     | ${[3, 3]}
                 `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                        let interval = res.iterations[iteration].intervals.all[index]
+                        let interval = res.iterations[iteration].intervals[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
                         expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
@@ -208,7 +208,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${3}  | ${[8, 9]}     | ${[9, 9]}
                 `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                        let interval = res.iterations[iteration].intervals.all[index]
+                        let interval = res.iterations[iteration].intervals[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
                         expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
@@ -242,7 +242,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${8}  | ${[24, 25]}   | ${[25, 25]}
                 `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                        let interval = res.iterations[iteration].intervals.all[index]
+                        let interval = res.iterations[iteration].intervals[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
                         expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
@@ -268,7 +268,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${3}  | ${[21, 25]}   | ${[25, 25]}
                 `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                        let interval = res.iterations[iteration].intervals.all[index]
+                        let interval = res.iterations[iteration].intervals[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
                         expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
@@ -287,7 +287,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${3}  | ${[16, 18]}   | ${[18, 18]}
                     `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                        let interval = res.iterations[iteration].intervals.all[index]
+                        let interval = res.iterations[iteration].intervals[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
                         expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
@@ -312,7 +312,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${8}  | ${[45, 49]}   | ${[49, 49]}
                     `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                        let interval = res.iterations[iteration].intervals.all[index]
+                        let interval = res.iterations[iteration].intervals[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
                         expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
@@ -337,7 +337,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${8}  | ${[48, 49]}   | ${[49, 49]}
                     `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                        let interval = res.iterations[iteration].intervals.all[index]
+                        let interval = res.iterations[iteration].intervals[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
                         expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })
@@ -362,7 +362,7 @@ describe('Cantor Library', function() {
                     ${1}        | ${8}  | ${[63, 64]}   | ${[64, 64]}
                     `('performs 2 iterations', ({ iteration, index, left, right }) => {
                     it(`iteration ${iteration}[${index}] has interval [${left[0]}/${left[1]}, ${right[0]}/${right[1]}]`, () => {
-                        let interval = res.iterations[iteration].intervals.all[index]
+                        let interval = res.iterations[iteration].intervals[index]
                         expect(interval.left.equals( new Fraction(left) )).toBeTruthy()
                         expect(interval.right.equals( new Fraction(right) )).toBeTruthy()
                     })

--- a/src/test/fraction.test.js
+++ b/src/test/fraction.test.js
@@ -26,11 +26,11 @@ describe('Fractions', function() {
         })
 
         it('fails to create a fraction when only one number is passed in', function(){
-            expect( () => new Fraction(1) ).toThrow(TypeError)
+            expect( () => new Fraction(1) ).toThrow(ArgumentError)
         })
 
         it('fails to create when non-numbers are passed', function(){
-            expect( () => new Fraction(new Fraction(1,2), 2 )).toThrow(TypeError)
+            expect( () => new Fraction(new Fraction(1,2), 2 )).toThrow(ArgumentError)
         })
 
         it('fails to create a fraction with zero in the denominator', function(){

--- a/src/test/fraction.test.js
+++ b/src/test/fraction.test.js
@@ -1,5 +1,5 @@
 import Fraction from '../models/fraction'
-import { ValueError, FracError } from '../shared/errors'
+import { FracError, ArgumentError } from '../shared/errors'
 
 describe('Fractions', function() {
 
@@ -102,7 +102,7 @@ describe('Fractions', function() {
             let frac_4_5 = new Fraction(4, 5)
 
             it('does not modify the original fractions', function() {
-                let sum = frac_2_5.add(frac_1_5)
+                let sum = frac_2_5.add(frac_1_5) //eslint-disable-line
                 expect(frac_2_5.num).toEqual(2)
                 expect(frac_2_5.den).toEqual(5)
 
@@ -147,20 +147,9 @@ describe('Fractions', function() {
                 expect(sum.den).toEqual(5)
             })
 
-            describe('addition with a scalar', function(){
-                it('it increases the numerator by that much', function(){
-                    expect( new Fraction(1,6).add(1).equals( new Fraction(2, 6) )).toBe(true)
-                })
-
-                it('does not modify the original Fraction', function(){
-                    let frac = new Fraction(1,6)
-                    frac.add(new Fraction(1,2))
-                    expect(new Fraction(1,6).equals(frac)).toBe(true)
-                })
+            it('Throws if passed anything except a Fraction', function(){
+                expect( () => new Fraction(1,6).add(1)).toThrow(ArgumentError)
             })
-
-
-
         })
 
         describe('subtraction', function(){
@@ -169,7 +158,7 @@ describe('Fractions', function() {
             let frac_2_5 = new Fraction(2, 5)
 
             it('does not modify the original fractions', function(){
-                let diff = frac_5_7.subtract(frac_2_5)
+                let diff = frac_5_7.subtract(frac_2_5) //eslint-disable-line
 
                 expect(frac_5_7.num).toEqual(5)
                 expect(frac_5_7.den).toEqual(7)
@@ -205,7 +194,7 @@ describe('Fractions', function() {
             })
 
             it('fails if passed an argument other than Fraction', function(){
-                expect( () => new Fraction(1,2).subtract(4) ).toThrow(ValueError)
+                expect( () => new Fraction(1,2).subtract(4) ).toThrow(ArgumentError)
             })
         })
 
@@ -215,7 +204,7 @@ describe('Fractions', function() {
             ${[1, 2]}   | ${[1, 4]}     | ${[1, 8]}
             ${[0, 2]}   | ${[1, 4]}     | ${[0, 8]}
             ${[15, 20]} | ${[1, 7]}     | ${[15, 140]}
-            `('multiplying a fraction by another fraction', ({first, second, result}) => {
+            `('multiplying a fraction by another fraction', ({ first, second, result }) => {
                 [first, second, result] = [first, second, result].map( frac => new Fraction(frac) )
 
                 it(`multiply ${first.str} by ${second.str} to get ${result.str}`, () => {
@@ -229,12 +218,17 @@ describe('Fractions', function() {
             ${[2, 18]}  | ${3}      | ${[6, 18]}
             ${[5, 7]}   | ${0}      | ${[0, 7]}
             ${[5, 7]}   | ${1}      | ${[5, 7]}
-            `('multiplying a fraction by a scalar', ({frac, scalar, result}) => {
+            `('multiplying a fraction by a scalar', ({ frac, scalar, result }) => {
                 [frac, result] = [frac, result].map( arr => new Fraction(arr) )
 
                 it(`multiply ${frac.str} by ${scalar} to get ${result}`, () => {
                     expect(frac.mult(scalar).equals(result)).toBeTruthy()
                 })
+            })
+
+            it('Fails if passed something other than a scalar or a Fraction', function(){
+                let frac = new Fraction(1, 2)
+                expect( () => frac.mult([2]) ).toThrow(ArgumentError)
             })
         })
     }) // fraction arithmetic
@@ -283,7 +277,7 @@ describe('Fractions', function() {
             ${[60, 92]} | ${[15, 23]}
             ${[56, 86]} | ${[28, 43]}
             ${[56, 63]} | ${[8, 9]}
-        `('properly reduces fractions', ({original, result}) => {
+        `('properly reduces fractions', ({ original, result }) => {
             [original, result] = [original, result].map( frac => new Fraction(frac) )
             it(`reduce ${original.str} to ${result.str}`, () => {
                 expect(original.reduce().equals(result)).toBeTruthy()
@@ -300,7 +294,7 @@ describe('Fractions', function() {
             ${[1, 86]}  | ${[0, 2]}     | ${[1, 86]}    | ${[0, 86]}
             ${[6, 16]}  | ${[8, 24]}    | ${[18, 48]}   | ${[16, 48]}
             ${[4, 16]}  | ${[2, 8]}     | ${[4, 16]}    | ${[4, 16]}
-        `('given a second fraction, converts itself and the passed in fraction to a common denominator', ({first, second, firstCommon, secondCommon}) => {
+        `('given a second fraction, converts itself and the passed in fraction to a common denominator', ({ first, second, firstCommon, secondCommon }) => {
             [first, second, firstCommon, secondCommon] = [first, second, firstCommon, secondCommon].map( frac => new Fraction(frac) )
 
             it(`convert ${first.str} => ${firstCommon.str} and ${second.str} => ${secondCommon.str}`, () => {
@@ -317,7 +311,7 @@ describe('Fractions', function() {
         })
 
         it('throws if something other than Fraction is passed', function(){
-            expect( () => new Fraction(1,2).commonDen(4) ).toThrow(ValueError)
+            expect( () => new Fraction(1,2).commonDen(4) ).toThrow(ArgumentError)
         })
     })
 })

--- a/src/test/fraction.test.js
+++ b/src/test/fraction.test.js
@@ -1,5 +1,5 @@
 import Fraction from '../models/fraction'
-import { FracError } from '../shared/errors'
+import { ValueError, FracError } from '../shared/errors'
 
 describe('Fractions', function() {
 
@@ -147,6 +147,20 @@ describe('Fractions', function() {
                 expect(sum.den).toEqual(5)
             })
 
+            describe('addition with a scalar', function(){
+                it('it increases the numerator by that much', function(){
+                    expect( new Fraction(1,6).add(1).equals( new Fraction(2, 6) )).toBe(true)
+                })
+
+                it('does not modify the original Fraction', function(){
+                    let frac = new Fraction(1,6)
+                    frac.add(new Fraction(1,2))
+                    expect(new Fraction(1,6).equals(frac)).toBe(true)
+                })
+            })
+
+
+
         })
 
         describe('subtraction', function(){
@@ -188,6 +202,10 @@ describe('Fractions', function() {
 
                 expect(diff.num).toEqual(0)
                 expect(diff.den).toEqual(5)
+            })
+
+            it('fails if passed an argument other than Fraction', function(){
+                expect( () => new Fraction(1,2).subtract(4) ).toThrow(ValueError)
             })
         })
 
@@ -296,6 +314,10 @@ describe('Fractions', function() {
                 expect(firstTest.den).toEqual(common)
                 expect(secondTest.den).toEqual(common)
             })
+        })
+
+        it('throws if something other than Fraction is passed', function(){
+            expect( () => new Fraction(1,2).commonDen(4) ).toThrow(ValueError)
         })
     })
 })

--- a/src/test/fraction.test.js
+++ b/src/test/fraction.test.js
@@ -4,14 +4,22 @@ import { FracError } from '../shared/errors'
 describe('Fractions', function() {
 
     describe('creating fractions', function() {
-        it('default creates a 1/1 fraction', function() {
+        it('default creates a 1/1 fraction if no arguments passed', function() {
             let frac = new Fraction
             expect(frac.num).toEqual(1)
             expect(frac.den).toEqual(1)
             expect( frac.num / frac.den).toEqual(1)
         })
-        it('creates a fraction for 1/2', function(){
+
+        it('creates a fraction for 1/2 passing in 1, 2', function(){
             let frac = new Fraction(1, 2)
+            expect(frac.num).toEqual(1)
+            expect(frac.den).toEqual(2)
+            expect( frac.num / frac.den).toEqual(0.5)
+        })
+
+        it('creates a fraction for 1/2 passing in an Array [1, 2]', function(){
+            let frac = new Fraction([1, 2])
             expect(frac.num).toEqual(1)
             expect(frac.den).toEqual(2)
             expect( frac.num / frac.den).toEqual(0.5)
@@ -21,7 +29,15 @@ describe('Fractions', function() {
             expect( () => new Fraction(1) ).toThrow(TypeError)
         })
 
-        it('fails to create a fraction for 2/1', function(){
+        it('fails to create when non-numbers are passed', function(){
+            expect( () => new Fraction(new Fraction(1,2), 2 )).toThrow(TypeError)
+        })
+
+        it('fails to create a fraction with zero in the denominator', function(){
+            expect( () => new Fraction(1,0)).toThrow(FracError.ZeroDenominator)
+        })
+
+        it('fails to create a fraction if it would be larger in magnitude than 1', function(){
             expect( () => new Fraction(2,1)).toThrow(FracError.FractionTooLarge)
         })
 
@@ -49,8 +65,20 @@ describe('Fractions', function() {
             [ new Fraction(0,2), new Fraction(1,2), true ],
             [ new Fraction(2,2), new Fraction(4,4), false ],
             [ new Fraction(2,3), new Fraction(1,8), false ],
-            [ new Fraction(1,3), new Fraction(3,4), true]])('lessThan', (lhs, rhs, answer) => {
+            [ new Fraction(1,3), new Fraction(3,4), true]
+        ])('lessThan', (lhs, rhs, answer) => {
             expect(lhs.lessThan(rhs)).toEqual(answer)
+        })
+
+        describe.each([
+            [ new Fraction(1,2), new Fraction(1,2), false ],
+            [ new Fraction(0,2), new Fraction(1,2), false ],
+            [ new Fraction(2,2), new Fraction(1,2), true ],
+            [ new Fraction(2,2), new Fraction(4,4), false ],
+            [ new Fraction(2,3), new Fraction(1,8), true ],
+            [ new Fraction(1,3), new Fraction(3,4), false]
+        ])('greaterThan', (lhs, rhs, answer) => {
+            expect(lhs.greaterThan(rhs)).toEqual(answer)
         })
 
         describe.each([
@@ -74,7 +102,7 @@ describe('Fractions', function() {
             let frac_4_5 = new Fraction(4, 5)
 
             it('does not modify the original fractions', function() {
-                let sum = frac_2_5.add(frac_1_5) // eslint-disable-line
+                let sum = frac_2_5.add(frac_1_5)
                 expect(frac_2_5.num).toEqual(2)
                 expect(frac_2_5.den).toEqual(5)
 
@@ -127,7 +155,7 @@ describe('Fractions', function() {
             let frac_2_5 = new Fraction(2, 5)
 
             it('does not modify the original fractions', function(){
-                let diff = frac_5_7.subtract(frac_2_5) // eslint-disable-line
+                let diff = frac_5_7.subtract(frac_2_5)
 
                 expect(frac_5_7.num).toEqual(5)
                 expect(frac_5_7.den).toEqual(7)
@@ -163,77 +191,110 @@ describe('Fractions', function() {
             })
         })
 
-        describe('reducing a fraction', function(){
-            describe.each([
-                [new Fraction(0,4)],
-                [new Fraction(0, 94)],
-                [new Fraction(0, 1)],
-                [new Fraction(0, 86)]
-            ])('does not reduce fractions with zero in the numerator', (orig) => {
-                it(`do not reduce ${orig.str}`, () => {
-                    expect(orig.reduce().num).toEqual(orig.num)
-                    expect(orig.reduce().den).toEqual(orig.den)
+        describe('multiplication', function(){
+            describe.each`
+            first       | second        | result
+            ${[1, 2]}   | ${[1, 4]}     | ${[1, 8]}
+            ${[0, 2]}   | ${[1, 4]}     | ${[0, 8]}
+            ${[15, 20]} | ${[1, 7]}     | ${[15, 140]}
+            `('multiplying a fraction by another fraction', ({first, second, result}) => {
+                [first, second, result] = [first, second, result].map( frac => new Fraction(frac) )
+
+                it(`multiply ${first.str} by ${second.str} to get ${result.str}`, () => {
+                    expect(first.mult(second).equals(result)).toBeTruthy()
                 })
             })
 
-            describe.each([
-                [new Fraction(4,4)],
-                [new Fraction(94, 94)],
-                [new Fraction(1, 1)],
-                [new Fraction(86, 86)]
-            ])('does not reduce fractions with the same numerator and denominator', (orig) => {
-                it(`do not reduce ${orig.str}`, () => {
-                    expect(orig.reduce().num).toEqual(orig.num)
-                    expect(orig.reduce().den).toEqual(orig.den)
+            describe.each`
+            frac        | scalar    | result
+            ${[1, 2]}   | ${2}      | ${[1, 1]}
+            ${[2, 18]}  | ${3}      | ${[6, 18]}
+            ${[5, 7]}   | ${0}      | ${[0, 7]}
+            ${[5, 7]}   | ${1}      | ${[5, 7]}
+            `('multiplying a fraction by a scalar', ({frac, scalar, result}) => {
+                [frac, result] = [frac, result].map( arr => new Fraction(arr) )
+
+                it(`multiply ${frac.str} by ${scalar} to get ${result}`, () => {
+                    expect(frac.mult(scalar).equals(result)).toBeTruthy()
                 })
             })
+        })
+    }) // fraction arithmetic
 
-            describe.each([
-                [new Fraction(1,4)],
-                [new Fraction(13, 94)],
-                [new Fraction(27, 35)],
-                [new Fraction(3, 86)]
-            ])('does not reduce fractions that cannot be reduced', (orig) => {
-                it(`do not reduce ${orig.str}`, () => {
-                    expect(orig.reduce().num).toEqual(orig.num)
-                    expect(orig.reduce().den).toEqual(orig.den)
-                })
+    describe('reducing a fraction', function(){
+        describe.each([
+            [new Fraction(0,4)],
+            [new Fraction(0, 94)],
+            [new Fraction(0, 1)],
+            [new Fraction(0, 86)]
+        ])('does not reduce fractions with zero in the numerator', (orig) => {
+            it(`do not reduce ${orig.str}`, () => {
+                expect(orig.reduce().num).toEqual(orig.num)
+                expect(orig.reduce().den).toEqual(orig.den)
             })
+        })
 
-            describe.each([
-                [new Fraction(2,4), new Fraction(1,2)],
-                [new Fraction(60, 94), new Fraction(30, 47)],
-                [new Fraction(60, 92), new Fraction(15, 23)],
-                [new Fraction(56, 86), new Fraction(28, 43)],
-                [new Fraction(56, 63), new Fraction(8, 9)]
-            ])('properly reduces fractions', (orig, result) => {
-                it(`reduce ${orig.str} to ${result.str}`, () => {
-                    expect(orig.reduce().num).toEqual(result.num)
-                    expect(orig.reduce().den).toEqual(result.den)
-                })
+        describe.each([
+            [new Fraction(4,4)],
+            [new Fraction(94, 94)],
+            [new Fraction(1, 1)],
+            [new Fraction(86, 86)]
+        ])('does not reduce fractions with the same numerator and denominator', (orig) => {
+            it(`do not reduce ${orig.str}`, () => {
+                expect(orig.reduce().num).toEqual(orig.num)
+                expect(orig.reduce().den).toEqual(orig.den)
+            })
+        })
+
+        describe.each([
+            [new Fraction(1,4)],
+            [new Fraction(13, 94)],
+            [new Fraction(27, 35)],
+            [new Fraction(3, 86)]
+        ])('does not reduce fractions that cannot be reduced', (orig) => {
+            it(`do not reduce ${orig.str}`, () => {
+                expect(orig.reduce().num).toEqual(orig.num)
+                expect(orig.reduce().den).toEqual(orig.den)
+            })
+        })
+
+        describe.each`
+            original    | result
+            ${[2,4]}    | ${[1,2]}
+            ${[60, 94]} | ${[30, 47]}
+            ${[60, 92]} | ${[15, 23]}
+            ${[56, 86]} | ${[28, 43]}
+            ${[56, 63]} | ${[8, 9]}
+        `('properly reduces fractions', ({original, result}) => {
+            [original, result] = [original, result].map( frac => new Fraction(frac) )
+            it(`reduce ${original.str} to ${result.str}`, () => {
+                expect(original.reduce().equals(result)).toBeTruthy()
             })
         })
     })
 
-    describe('static class method: Fraction.commonDen', function() {
-        describe.each([
-            [new Fraction(5, 7), new Fraction(1, 6), new Fraction(30, 42), new Fraction(7, 42)],
-            [new Fraction(5, 7), new Fraction(30, 47), new Fraction(235, 329), new Fraction(210, 329)],
-            [new Fraction(3, 4), new Fraction(7, 12), new Fraction(9, 12), new Fraction(7, 12)],
-            [new Fraction(1, 86), new Fraction(0, 2), new Fraction(1, 86), new Fraction(0, 86)],
-            [new Fraction(6, 16), new Fraction(8, 24), new Fraction(18, 48), new Fraction(16, 48)],
-            [new Fraction(4, 16), new Fraction(2, 8), new Fraction(4, 16), new Fraction(4, 16)]
-        ])('converts itself and the passed in fraction to a common denominator', (first, second, firstResult, secondResult) => {
-            it(`convert ${first.str} => ${firstResult.str} and ${second.str} => ${secondResult.str}`, () => {
-                let [firstTest, secondTest] = Fraction.commonDen(first, second)
+    describe('finding a common denominator', function() {
+        describe.each`
+            first       | second        | firstCommon   | secondCommon
+            ${[5, 7]}   | ${[1, 6]}     | ${[30, 42]}   | ${[7, 42]}
+            ${[5, 7]}   | ${[30, 47]}   | ${[235, 329]} | ${[210, 329]}
+            ${[3, 4]}   | ${[7, 12]}    | ${[9, 12]}    | ${[7, 12]}
+            ${[1, 86]}  | ${[0, 2]}     | ${[1, 86]}    | ${[0, 86]}
+            ${[6, 16]}  | ${[8, 24]}    | ${[18, 48]}   | ${[16, 48]}
+            ${[4, 16]}  | ${[2, 8]}     | ${[4, 16]}    | ${[4, 16]}
+        `('given a second fraction, converts itself and the passed in fraction to a common denominator', ({first, second, firstCommon, secondCommon}) => {
+            [first, second, firstCommon, secondCommon] = [first, second, firstCommon, secondCommon].map( frac => new Fraction(frac) )
 
-                expect(firstTest.num).toEqual(firstResult.num)
-                expect(firstTest.den).toEqual(firstResult.den)
+            it(`convert ${first.str} => ${firstCommon.str} and ${second.str} => ${secondCommon.str}`, () => {
+                let [firstTest, secondTest] = first.commonDen(second)
+                let common = firstCommon.den
 
-                expect(secondTest.num).toEqual(secondResult.num)
-                expect(secondTest.den).toEqual(secondResult.den)
+                expect(firstTest.equals(firstCommon)).toBeTruthy()
+                expect(secondTest.equals(secondCommon)).toBeTruthy()
 
-                expect(firstResult.den).toEqual(secondResult.den)
+                expect(firstTest.den).toEqual(secondTest.den)
+                expect(firstTest.den).toEqual(common)
+                expect(secondTest.den).toEqual(common)
             })
         })
     })

--- a/src/test/interval.test.js
+++ b/src/test/interval.test.js
@@ -1,6 +1,6 @@
 import Interval from '../models/interval'
 import Fraction from '../models/fraction'
-import { ValueError, IntervalRangeError } from '../shared/errors'
+import { ArgumentError, ValueError, IntervalRangeError } from '../shared/errors'
 
 describe('Interval', function() {
     describe('creating intervals', function(){
@@ -39,11 +39,11 @@ describe('Interval', function() {
         })
 
         it('fails if one argument is not Fraction', function() {
-            expect( () => { new Interval(new Fraction(0,2), 0) }).toThrow(TypeError)
+            expect( () => { new Interval(new Fraction(0,2), 0) }).toThrow(ArgumentError)
         })
 
         it('fails if passed no arguments with new', function(){
-            expect( () => new Interval ).toThrow(TypeError)
+            expect( () => new Interval ).toThrow(ArgumentError)
         })
     })
 
@@ -58,7 +58,7 @@ describe('Interval', function() {
         ${[[0,2],[2,2]]}    | ${[[0,7],[7,7]]}  | ${true}
         ${[[1,3],[2,3]]}    | ${[[3,9],[6,9]]}  | ${true}
         ${[[1,3],[2,3]]}    | ${[[4,12],[7,9]]} | ${false}
-    `('Interval equality', ({interval1, interval2, equal}) => {
+    `('Interval equality', ({ interval1, interval2, equal }) => {
         expect(new Interval(interval1).equals(new Interval(interval2))).toBe(equal)
     })
 

--- a/src/test/interval.test.js
+++ b/src/test/interval.test.js
@@ -9,14 +9,24 @@ describe('Interval', function() {
             ${[0, 2]}       | ${[1, 1]}         | ${[1, 1]}
             ${[0, 5]}       | ${[3, 5]}         | ${[3, 5]}
             ${[2, 3]}       | ${[18, 21]}       | ${[4, 21]}
-        `('when passed two appropriate fractions', ({ intervalLeft, intervalRight, correctLength }) => {
+        `('Creates an Interval [$left.str, $right.str] with length $correctLen.str', ({ intervalLeft, intervalRight, correctLength }) => {
             let left = new Fraction(intervalLeft)
             let right = new Fraction(intervalRight)
             let correctLen = new Fraction(correctLength)
-
-            it(`Creates an Interval [${left.str}, ${right.str}] with length ${correctLen.str}`, () => {
+            it('when passed two appropriate fractions', () => {
                 let testLen = new Interval(left, right).len.reduce()
                 expect(testLen.equals(correctLen)).toBeTruthy()
+            })
+
+            it('when passed an array containing two sub-arrays representing the endpoints', () => {
+                let testInt = new Interval([intervalLeft, intervalRight])
+                let testLen = testInt.len.reduce()
+                expect(testLen.equals(correctLen)).toBeTruthy()
+
+                expect(testInt.left.num).toEqual(intervalLeft[0])
+                expect(testInt.left.den).toEqual(intervalLeft[1])
+                expect(testInt.right.num).toEqual(intervalRight[0])
+                expect(testInt.right.den).toEqual(intervalRight[1])
             })
         })
 
@@ -44,82 +54,95 @@ describe('Interval', function() {
     })
 
     describe.each`
-        intervalL   | intervalR     | commonL       | commonR
-        ${[1, 5]}   | ${[7, 10]}    | ${[2, 10]}    | ${[7, 10]}
-        ${[2, 7]}   | ${[4, 5]}     | ${[10, 35]}   | ${[28, 35]}
-        ${[3, 11]}  | ${[34, 90]}   | ${[270, 990]} | ${[374, 990]}
-    `('converts the endpoints to a common denominator', function({ intervalL, intervalR, commonL, commonR }) {
-        let originalInterval = new Interval(new Fraction(intervalL), new Fraction(intervalR))
-        let convertedCorrect = new Interval(new Fraction(commonL), new Fraction(commonR))
+        interval1           | interval2         | equal
+        ${[[0,2],[2,2]]}    | ${[[0,7],[7,7]]}  | ${true}
+        ${[[1,3],[2,3]]}    | ${[[3,9],[6,9]]}  | ${true}
+        ${[[1,3],[2,3]]}    | ${[[4,12],[7,9]]} | ${false}
+    `('Interval equality', ({interval1, interval2, equal}) => {
+        expect(new Interval(interval1).equals(new Interval(interval2))).toBe(equal)
+    })
 
-        it(`given Interval ${originalInterval.strMinimal}, convert to ${convertedCorrect.strMinimal}`, () => {
-            let convertedTest = originalInterval.commonDen()
-            expect(convertedTest.left.equals(convertedCorrect.left)).toBeTruthy()
-            expect(convertedTest.right.equals(convertedCorrect.right)).toBeTruthy()
-            expect(convertedTest.left.den).toEqual(convertedCorrect.left.den)
-            expect(convertedTest.right.den).toEqual(convertedCorrect.right.den)
+    describe('Converting endpoints to a common denominator', function() {
+        describe.each`
+            intervalL   | intervalR     | commonL       | commonR
+            ${[1, 5]}   | ${[7, 10]}    | ${[2, 10]}    | ${[7, 10]}
+            ${[2, 7]}   | ${[4, 5]}     | ${[10, 35]}   | ${[28, 35]}
+            ${[3, 11]}  | ${[34, 90]}   | ${[270, 990]} | ${[374, 990]}
+        `('converts the endpoints to a common denominator', function({ intervalL, intervalR, commonL, commonR }) {
+            let originalInterval = new Interval(new Fraction(intervalL), new Fraction(intervalR))
+            let convertedCorrect = new Interval(new Fraction(commonL), new Fraction(commonR))
+
+            it(`given Interval ${originalInterval.strMinimal}, convert to ${convertedCorrect.strMinimal}`, () => {
+                let convertedTest = originalInterval.commonDen()
+                expect(convertedTest.left.equals(convertedCorrect.left)).toBeTruthy()
+                expect(convertedTest.right.equals(convertedCorrect.right)).toBeTruthy()
+                expect(convertedTest.left.den).toEqual(convertedCorrect.left.den)
+                expect(convertedTest.right.den).toEqual(convertedCorrect.right.den)
+            })
+        })
+
+        describe.each`
+            interval                | newDen | specificLArr  | specificRArr
+            ${[[1, 5], [7, 10]]}    | ${100} | ${[20, 100]}  | ${[70, 100]}
+            ${[[2, 7], [4, 5]]}     | ${105} | ${[30, 105]}  | ${[84, 105]}
+            ${[[1, 4], [1, 3]]}     | ${12}  | ${[3, 12]}    | ${[4, 12]}
+        `('converts the endpoints to a specified denominator', function({ interval, newDen, specificLArr, specificRArr }) {
+            let originalInterval = new Interval(interval)
+            let commonL = new Fraction(specificLArr)
+            let commonR = new Fraction(specificRArr)
+
+            it(`given Interval ${originalInterval.strMinimal}, convert to [${commonL}, ${commonR}]`, () => {
+                let convertedInterval = originalInterval.commonDen(newDen)
+                expect(convertedInterval.left.equals(commonL)).toBeTruthy()
+                expect(convertedInterval.right.equals(commonR)).toBeTruthy()
+            })
+        })
+
+        describe.each`
+            interval                | newDen
+            ${[[1, 5], [7, 10]]}    | ${15}
+            ${[[2, 7], [4, 5]]}     | ${28}
+            ${[[1, 4], [1, 3]]}     | ${16}
+        `('errors if endpoints cannot be converted to the given denominator', function({ interval, newDen }) {
+            it(`Interval ${interval} can't convert to denominator ${newDen}`, () => {
+                expect( () => new Interval(interval).commonDen(newDen) ).toThrow(ValueError)
+            })
+
         })
     })
 
-    describe.each`
-        interval                | newDen | specificLArr  | specificRArr
-        ${[[1, 5], [7, 10]]}    | ${100} | ${[20, 100]}  | ${[70, 100]}
-        ${[[2, 7], [4, 5]]}     | ${105} | ${[30, 105]}  | ${[84, 105]}
-        ${[[1, 4], [1, 3]]}     | ${12}  | ${[3, 12]}    | ${[4, 12]}
-    `('converts the endpoints to a specified denominator', function({ interval, newDen, specificLArr, specificRArr }) {
-        let originalInterval = new Interval(interval)
-        let commonL = new Fraction(specificLArr)
-        let commonR = new Fraction(specificRArr)
+    describe('subtracting a sub-interval from an interval', function(){
+        describe.each`
+            interval            | toSubtract            | resultL               | resultR
+            ${[[0, 5], [5, 5]]} | ${[[1, 5], [2, 5]]}   | ${[[0, 5],[1, 5]]}    | ${[[2, 5], [5, 5]]}
+            ${[[0, 1], [1, 1]]} | ${[[2, 4], [3, 4]]}   | ${[[0, 4], [2, 4]]}   | ${[[3, 4], [4, 4]]}
+            ${[[1, 2], [7, 8]]} | ${[[11, 16], [6, 8]]} | ${[[8, 16], [11, 16]]}| ${[[12, 16], [14, 16]]}
+        `('subtracting a gap from an interval returns two subintervals', function({ interval, toSubtract, resultL, resultR }) {
+            interval = new Interval(interval)
+            toSubtract = new Interval(toSubtract)
+            resultL = new Interval(resultL)
+            resultR = new Interval(resultR)
+            it(`from ${interval.strMinimal}, subtract ${toSubtract.strMinimal}`, () => {
+                let result = interval.subtract(toSubtract)
+                expect(result[0].left.equals(resultL.left)).toBeTruthy()
+                expect(result[0].right.equals(resultL.right)).toBeTruthy()
 
-        it(`given Interval ${originalInterval.strMinimal}, convert to [${commonL}, ${commonR}]`, () => {
-            let convertedInterval = originalInterval.commonDen(newDen)
-            expect(convertedInterval.left.equals(commonL)).toBeTruthy()
-            expect(convertedInterval.right.equals(commonR)).toBeTruthy()
-        })
-    })
-
-    describe.each`
-        interval                | newDen
-        ${[[1, 5], [7, 10]]}    | ${15}
-        ${[[2, 7], [4, 5]]}     | ${28}
-        ${[[1, 4], [1, 3]]}     | ${16}
-    `('errors if endpoints cannot be converted to the given denominator', function({ interval, newDen }) {
-        it(`Interval ${interval} can't convert to denominator ${newDen}`, () => {
-            expect( () => new Interval(interval).commonDen(newDen) ).toThrow(ValueError)
+                expect(result[1].left.equals(resultR.left)).toBeTruthy()
+                expect(result[1].right.equals(resultR.right)).toBeTruthy()
+            })
         })
 
-    })
-
-    describe.each`
-        interval            | toSubtract            | resultL               | resultR
-        ${[[0, 5], [5, 5]]} | ${[[1, 5], [2, 5]]}   | ${[[0, 5],[1, 5]]}    | ${[[2, 5], [5, 5]]}
-        ${[[0, 1], [1, 1]]} | ${[[2, 4], [3, 4]]}   | ${[[0, 4], [2, 4]]}   | ${[[3, 4], [4, 4]]}
-        ${[[1, 2], [7, 8]]} | ${[[11, 16], [6, 8]]} | ${[[8, 16], [11, 16]]}| ${[[12, 16], [14, 16]]}
-    `('subtracting a gap from an interval returns two subintervals', function({ interval, toSubtract, resultL, resultR }) {
-        interval = new Interval(interval)
-        toSubtract = new Interval(toSubtract)
-        resultL = new Interval(resultL)
-        resultR = new Interval(resultR)
-        it(`from ${interval.strMinimal}, subtract ${toSubtract.strMinimal}`, () => {
-            let result = interval.subtract(toSubtract)
-            expect(result[0].left.equals(resultL.left)).toBeTruthy()
-            expect(result[0].right.equals(resultL.right)).toBeTruthy()
-
-            expect(result[1].left.equals(resultR.left)).toBeTruthy()
-            expect(result[1].right.equals(resultR.right)).toBeTruthy()
-        })
-    })
-
-    describe.each`
-        interval                | toSubtract
-        ${[[1, 3], [2, 3]]}     | ${[[2, 7], [4, 9]]}
-        ${[[1, 3], [190, 200]]} | ${[[16, 49], [191, 200]]}
-        ${[[1, 2], [2, 3]]}     | ${[[1, 2], [7, 8]]}
-    `('fails if trying to subtract intervals which are not contained in the parent interval', function({ interval, toSubtract }) {
-        interval = new Interval(interval)
-        toSubtract = new Interval(toSubtract)
-        it(`from ${interval.strMinimal}, fail to subtract ${toSubtract.strMinimal}`, () => {
-            expect( () => interval.subtract(toSubtract)).toThrow(IntervalRangeError)
+        describe.each`
+            interval                | toSubtract
+            ${[[1, 3], [2, 3]]}     | ${[[2, 7], [4, 9]]}
+            ${[[1, 3], [190, 200]]} | ${[[16, 49], [191, 200]]}
+            ${[[1, 2], [2, 3]]}     | ${[[1, 2], [7, 8]]}
+        `('fails if trying to subtract intervals which are not contained in the parent interval', function({ interval, toSubtract }) {
+            interval = new Interval(interval)
+            toSubtract = new Interval(toSubtract)
+            it(`from ${interval.strMinimal}, fail to subtract ${toSubtract.strMinimal}`, () => {
+                expect( () => interval.subtract(toSubtract)).toThrow(IntervalRangeError)
+            })
         })
     })
 })

--- a/src/test/interval_collection.test.js
+++ b/src/test/interval_collection.test.js
@@ -3,16 +3,14 @@ import Interval from '../models/interval'
 import Fraction from '../models/fraction'
 import { checkSequence } from '../models/interval_collection'
 import { type, checkArrContents } from '../shared/utils'
-import { IntervalRangeError, ValueError, IntervalSequenceError } from '../shared/errors'
-
-window.type = type
+import { IntervalSequenceError } from '../shared/errors'
 
 let sampleIntervals = describe.each`
-    index   | interval1                | interval2                  | interval1Common                       | interval2Common
-    ${0}    | ${[[0, 4],    [1, 8]]}   | ${[[2, 8],     [3, 7]]}    | ${[[0, 56],       [7, 56]]}           | ${[[14, 56],      [24, 56]]}
-    ${1}    | ${[[1, 11],   [7, 27]]}  | ${[[2, 7],     [8, 9]]}    | ${[[189, 2079],   [539, 2079]]}       | ${[[594, 2079],   [1848, 2079]]}
-    ${2}    | ${[[5, 18],   [1, 3]]}   | ${[[11, 28],   [14, 17]]}  | ${[[1190, 4284],  [1428, 4284]]}      | ${[[1683, 4284],  [3528, 4284]]}
-    ${3}    | ${[[0, 9],    [2, 27]]}  | ${[[4, 29],    [11, 19]]}  | ${[[0, 14877],    [1102, 14877]]}     | ${[[2052, 14877], [8613, 14877]]}
+    index   | interval1                | interval2
+    ${0}    | ${[[0, 4],    [1, 8]]}   | ${[[2, 8],     [3, 7]]}
+    ${1}    | ${[[1, 11],   [7, 27]]}  | ${[[2, 7],     [8, 9]]}
+    ${2}    | ${[[5, 18],   [1, 3]]}   | ${[[11, 28],   [14, 17]]}
+    ${3}    | ${[[0, 9],    [2, 27]]}  | ${[[4, 29],    [11, 19]]}
 `
 let sampleInterval1 = new Interval([ [0, 4], [1, 8] ])
 let sampleInterval2 = new Interval([ [2, 8], [3, 7] ])
@@ -27,8 +25,6 @@ describe('Ensure that all intervals to be added to the collection are sequential
         let intArr = [sampleInterval2, sampleInterval1]
         expect( () => checkSequence(intArr)).toThrow(IntervalSequenceError)
     })
-
-
 })
 
 describe('IntervalCollection', function() {
@@ -44,6 +40,20 @@ describe('IntervalCollection', function() {
         new Fraction(475, 2079),
         new Fraction(2201, 4284),
         new Fraction(7214, 14877)
+    ]
+
+    let interval1Common = [
+        new Interval([[0, 56],       [7, 56]]),
+        new Interval([[189, 2079],   [539, 2079]]),
+        new Interval([[1190, 4284],  [1428, 4284]]),
+        new Interval([[0, 14877],    [1102, 14877]])
+    ]
+
+    let interval2Common = [
+        new Interval([[14, 56],      [24, 56]]),
+        new Interval([[594, 2079],   [1848, 2079]]),
+        new Interval([[1683, 4284],  [3528, 4284]]),
+        new Interval([[2052, 14877], [8613, 14877]])
     ]
 
     describe('Creating IntervalCollections', function() {
@@ -108,11 +118,11 @@ describe('IntervalCollection', function() {
         })
     })
 
-    sampleIntervals('converting all endpoints to a common denominator', function({ interval1, interval2, interval1Common, interval2Common }){
+    sampleIntervals('converting all endpoints to a common denominator', function({ index, interval1, interval2 }){
 
         it('it converts all endpoints to a common denominator', () => {
             let testArr = new IntervalCollection([ new Interval(interval1), new Interval(interval2) ]).commonDen()
-            let correctColl = new IntervalCollection([ new Interval(interval1Common), new Interval(interval2Common) ])
+            let correctColl = new IntervalCollection([ interval1Common[index], interval2Common[index] ])
 
             expect( testArr[0].left.equals(correctColl.intervals[0].left) ).toBeTruthy()
             expect( testArr[0].right.equals(correctColl.intervals[0].right) ).toBeTruthy()

--- a/src/test/utils.test.js
+++ b/src/test/utils.test.js
@@ -1,5 +1,5 @@
 import { lcm, type, checkArrContents, gcd } from '../shared/utils'
-import { ValueError } from '../shared/errors'
+import { ValueError, ArgumentError } from '../shared/errors'
 import Fraction from '../models/fraction'
 
 describe('Shared Utilities', function(){
@@ -45,7 +45,7 @@ describe('Shared Utilities', function(){
         })
 
         it('errors if anything other than a number is passed in', function(){
-            expect( () => lcm([3,7,12, null, 34]) ).toThrow(TypeError)
+            expect( () => lcm([3,7,12, null, 34]) ).toThrow(ArgumentError)
         })
     })
 
@@ -80,12 +80,12 @@ describe('Shared Utilities', function(){
         })
 
         it('fails if passed something other than an array', function() {
-            expect( () => checkArrContents(new Fraction(1,2), 'Fraction') ).toThrow(TypeError)
+            expect( () => checkArrContents(new Fraction(1,2), 'Fraction') ).toThrow(ArgumentError)
         })
 
         it('fails if array has incongruous items', function() {
-            expect( () => checkArrContents([ 1, 2, 4, '5', 6], 'number')).toThrow(TypeError)
-            expect( () => checkArrContents([ new Fraction(1,2), new Fraction(1,3), undefined, new Fraction(1, 6)], 'Fraction')).toThrow(TypeError)
+            expect( () => checkArrContents([ 1, 2, 4, '5', 6], 'number')).toThrow(ArgumentError)
+            expect( () => checkArrContents([ new Fraction(1,2), new Fraction(1,3), undefined, new Fraction(1, 6)], 'Fraction')).toThrow(ArgumentError)
         })
     })
 })

--- a/src/test/utils.test.js
+++ b/src/test/utils.test.js
@@ -43,6 +43,10 @@ describe('Shared Utilities', function(){
         it('does not compute LCM when zero is included', function() {
             expect(() => lcm([5,34,17,0])).toThrow(ValueError)
         })
+
+        it('errors if anything other than a number is passed in', function(){
+            expect( () => lcm([3,7,12, null, 34]) ).toThrow(TypeError)
+        })
     })
 
     describe('type', function(){
@@ -73,6 +77,10 @@ describe('Shared Utilities', function(){
                 let result = checkArrContents(arr, desiredType)
                 expect(result).toBeTruthy()
             })
+        })
+
+        it('fails if passed something other than an array', function() {
+            expect( () => checkArrContents(new Fraction(1,2), 'Fraction') ).toThrow(TypeError)
         })
 
         it('fails if array has incongruous items', function() {


### PR DESCRIPTION
- discovered an unexpected error was being caught by tests when using built-in error classes (TypeError) - removed all use of built-in errors and replaced with custom error classes
- refactored out IntervalArr and moved functionality into IntervalCollection
- moved Fraction.commonDen to an instance method because I can't remember why I made it static in the first place
- added tests to get to 100% coverage