### PR TITLE
35 display gap labels

### DIFF
--- a/.github/workflows/update-coverage-in-readme.yml
+++ b/.github/workflows/update-coverage-in-readme.yml
@@ -35,8 +35,8 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: schneegans/dynamic-badges-action@v1.6.0
         with:
-          auth: ${{ secrets.JEST_COVERAGE_COMMENT }}
-          gistID: 5e90d640f8c212ab7bbac38f72323f80
+          auth: ${{ secrets.GITHUB_SECRET}}
+          gistID: afab260d8a27deb3e4240334bab4bfa5
           filename: jest-coverage-comment__main.json
           label: coverage
           message: ${{ steps.coverageComment.outputs.coverage }}%

--- a/src/components/Numberline.js
+++ b/src/components/Numberline.js
@@ -142,8 +142,10 @@ const Numberline = ({ intCol, isDemo }) => {
             }
         })
 
+        // the pre-submission "demo" labels all segments
         if(isDemo){
-            let segPix = []
+            // if I wanted to make the labels clickable, or position different labels above them
+            //let segPix = []
             for(let i = 0; i <= commonD; i++){
                 // put a point over all segments
                 const dotPix = start + (i * segmentLen)
@@ -155,7 +157,7 @@ const Numberline = ({ intCol, isDemo }) => {
                 if(i < commonD){
                     ctx.font = `${determineFontSize(commonD)}px Verdana`
                     const segMid = start + (segmentLen * i) + segmentLen/2
-                    segPix.push(segMid)
+                    //segPix.push(segMid)
                     ctx.fillStyle = '#e5b513'
                     ctx.textBaseline = 'bottom'
                     const numBottomMargin = 15
@@ -163,6 +165,21 @@ const Numberline = ({ intCol, isDemo }) => {
                 }
             }
         }
+
+        // label the gaps alphabetically from left to right
+        if(!isDemo){
+            intCol.gaps.forEach( (interval, index) => {
+            const startPix = start + (interval.left.num * segmentLen)
+            const segDrawLen = interval.len.num * segmentLen
+            const endPix = startPix + segDrawLen
+            const midPoint = (segDrawLen/2) + startPix
+            ctx.fillStyle = '#609ab8'
+            ctx.textBaseline = 'bottom'
+            const numBottomMargin = 15
+            ctx.fillText( String.fromCharCode(index + 65), midPoint, midH - numBottomMargin )
+            })
+        }
+
     }
 
     return(


### PR DESCRIPTION
closes #35 - display alphabetic labels for gaps
also:
- attempt number 3-ish to get a coverage badge