### PR TITLE
display fraction values better

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 .eslintrc.js
 node_modules
-App.js

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useState, useEffect } from 'react'
-import { AiOutlineDownload, AiOutlineCloseCircle, AiOutlinePlusCircle, AiOutlineArrowUp } from 'react-icons/ai'
+//import { AiOutlineDownload, AiOutlineCloseCircle, AiOutlinePlusCircle, AiOutlineArrowUp } from 'react-icons/ai'
+import { AiOutlineDownload, AiOutlineCloseCircle, AiOutlineArrowUp } from 'react-icons/ai'
 import { BsBorderStyle } from 'react-icons/bs'
 
 import Cantor from './models/cantor'
@@ -28,7 +29,7 @@ function App() {
     const [cantor, setCantor] = useState(null)
     const[displayResults, setDisplayResults] = useState(false)
     const[disableCanvas, setDisableCanvas] = useState(false)
-    const[notification, setNotification] = useState({'notifications': []})
+    //const[notification, setNotification] = useState({'notifications': []})
 
     useEffect( () => {
         let defaultCantor = new Cantor(stateDefaults['numSegments'], stateDefaults['toRemove'], stateDefaults['numIter'])
@@ -64,7 +65,7 @@ function App() {
     }
 
     const validateFields = () => {
-        let errorState = {...formErrors}
+        let errorState = { ...formErrors }
 
         //validate numSegments
         let legalNumSeg = /^\s*\d+\s*$/
@@ -125,8 +126,7 @@ function App() {
         setFormErrors(errorState)
     }
 
-    const handleLoseFocus = (event) => {
-        const elementName = event.target.name
+    const handleLoseFocus = () => {
         validateFields()
     }
 
@@ -177,7 +177,7 @@ function App() {
         setCantor(cantor.performOneIteration(lastIntervalCol))
     }
 */
-    const showResultsTopButtons = (cantor) => {
+    const showResultsTopButtons = () => {
         const resultsTopButtonConfig = {
             'download': {
                 'text':     'Download Data',
@@ -199,7 +199,7 @@ function App() {
         return(<ButtonSet buttonSetConfig={resultsTopButtonConfig}/>)
     }
 
-    const showResultsBottomButtons = (cantor) => {
+    const showResultsBottomButtons = () => {
         const resultsBottomButtonsConfig = {
             /*
             'oneMore': {
@@ -239,10 +239,6 @@ function App() {
         setNumSegments(1)
         setNumIter(1)
         setToRemove([])
-    }
-
-    const tempHandler = () => {
-        typeof Function.prototype === "function"
     }
 
     const handleDownloadReport = () => {

--- a/src/components/CantorTable.js
+++ b/src/components/CantorTable.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Fraction from '../models/fraction'
+import { getLabel } from '../shared/utils'
+import IntervalDisplay from './IntervalDisplay'
+import FracDisplay from './FracDisplay'
 
 const CantorTable = ({ intervalArr, kind, totLen }) => {
-    const numOrLetter = (kind, idx) => kind === 'segment' ? idx + 1 : String.fromCharCode(idx + 65)
+    const numOrLetter = (kind, idx) => kind === 'segment' ? idx + 1 : getLabel(idx)
 
     return(
         <div className={`cantor-result-${kind}s`}>
@@ -23,8 +26,12 @@ const CantorTable = ({ intervalArr, kind, totLen }) => {
                         return(
                             <tr key={index} >
                                 <td className="cantor-table-row">{numOrLetter(kind, index)}</td>
-                                <td className="cantor-table-row">{interval.strMinimal}</td>
-                                <td className="cantor-table-row">{interval.len.str}</td>
+                                <td className="cantor-table-row">
+                                    <IntervalDisplay interval={interval}/>
+                                </td>
+                                <td className="cantor-table-row">
+                                    <FracDisplay frac={interval.len}/>
+                                </td>
                             </tr>
                         )
                     }) }

--- a/src/components/FracDisplay.js
+++ b/src/components/FracDisplay.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Fraction from '../models/fraction'
+
+const FracDisplay = ({ frac }) => {
+    return(
+        <span className='frac-display'>
+            <span>{frac.num}</span>
+            <span className='frac-line'>
+            </span>
+            <span>{frac.den}</span>
+        </span>
+    )
+}
+
+FracDisplay.propTypes = {
+    frac: PropTypes.instanceOf(Fraction)
+}
+
+export default FracDisplay
+/*
+<div>a <span style="display:inline-flex;flex-direction:column;vertical-align:middle;">
+<span>1</span>
+<span style="border-top:1px solid">2</span>
+</span> b
+</div>
+*/

--- a/src/components/IntervalDisplay.js
+++ b/src/components/IntervalDisplay.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Interval from '../models/interval'
+import FracDisplay from './FracDisplay'
+
+const IntervalDisplay = ({ interval }) => {
+    return(
+        <div className='interval-display'>
+            <div className='parens-left'></div>
+            <FracDisplay frac={interval.left.reduce()}/>
+            ,
+            <FracDisplay frac={interval.right.reduce()}/>
+            <span className='parens-right'></span>
+        </div>
+    )
+}
+
+IntervalDisplay.propTypes = {
+    interval: PropTypes.instanceOf(Interval)
+}
+
+export default IntervalDisplay

--- a/src/components/SetupStep.js
+++ b/src/components/SetupStep.js
@@ -19,13 +19,13 @@ const SetupStep = (props) => {
             )
         } else {
             return(
-                    <input
-                        value={inputState}
-                        name={name}
-                        onChange={handleInputChange}
-                        onBlur={handleLoseFocus}
-                        disabled={ name==='toRemove' && anyErrors('numSegments') }
-                    />
+                <input
+                    value={inputState}
+                    name={name}
+                    onChange={handleInputChange}
+                    onBlur={handleLoseFocus}
+                    disabled={ name==='toRemove' && anyErrors('numSegments') }
+                />
             )
         }
     }

--- a/src/index.css
+++ b/src/index.css
@@ -156,7 +156,7 @@ a {
     border-color: var(--color-bluish);
     border-width: 2px;
     text-align: center;
-    padding: 20px;
+    padding: 20px 0px;
 }
 
 .cantor-table-header {
@@ -168,6 +168,36 @@ a {
     font-size: 1.5rem;
     font-weight: 400;
     text-transform: capitalize;
+}
+
+.interval-display {
+    display: flex;
+    justify-content: center;
+}
+
+.parens-left {
+    border-style: solid;
+    border-color: black;
+    border-width: 2px 0 2px 2px;
+    width: 3px;
+    margin: 0 5px 0 0;
+}
+
+.parens-right {
+    border-style: solid;
+    border-color: black;
+    border-width: 2px 2px 2px 0;
+    width: 3px;
+    margin: 0 0 0 5px;
+}
+.frac-display {
+    display: inline-flex;
+    flex-direction: column;
+    vertical-align: middle;
+}
+
+.frac-line {
+    border-top: 2px solid;
 }
 
 /****************/

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -93,6 +93,13 @@ function checkArrContents(arr, typeStr){
     return true
 }
 
+function getLabel(index){
+    if(index < 26){
+        return String.fromCharCode(Math.floor(index + 65))
+    } else {
+        return `${String.fromCharCode(Math.floor(index/26) + 64)}${String.fromCharCode(index%26 + 65)}`
+    }
+}
 
 /* istanbul ignore if */
 if (process.env['NODE_ENV'] === 'test') {
@@ -103,5 +110,6 @@ export {
     lcm,
     type,
     checkArrContents,
-    checkUnsafe
+    checkUnsafe,
+    getLabel
 }


### PR DESCRIPTION
closes:
#11 - better gap labels past 26 entries - after "Z" is reached, begin again with "AA", "AB", etc
#43 - reduce fraction font size  when many points nearby
#45 - display fractions in tables more nicely