### PR TITLE
59 spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-error-boundary": "^3.1.4",
         "react-icons": "^4.7.1",
         "react-scripts": "5.0.1",
+        "react-spinners": "^0.13.8",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -14431,6 +14432,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -27371,6 +27381,12 @@
           "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
         }
       }
+    },
+    "react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "requires": {}
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-error-boundary": "^3.1.4",
     "react-icons": "^4.7.1",
     "react-scripts": "5.0.1",
+    "react-spinners": "^0.13.8",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -319,9 +319,6 @@ function App() {
         return(<ErrorNotification error={notification}/>)
     }
 
-    const dummy = () => {
-    }
-
     return (
         <div>
             <Header/>

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import SetupCantor from './components/SetupCantor'
 import ButtonSet from './components/ButtonSet'
 import Numberline from './components/Numberline'
 import CantorResults from './components/CantorResults'
+import Demo from './components/Demo'
 
 function App() {
     const [numSegments, setNumSegments] = useState(stateDefaults['numSegments'])
@@ -28,10 +29,11 @@ function App() {
         'numIter':      null
     })
     const [cantor, setCantor] = useState(null)
-    const[displayResults, setDisplayResults] = useState(false)
-    const[disableCanvas, setDisableCanvas] = useState(false)
-    const[disableSubmit, setDisableSubmit] = useState(false)
-    const[notification, setNotification] = useState()
+    const [displayResults, setDisplayResults] = useState(false)
+    const [disableCanvas, setDisableCanvas] = useState(false)
+    const [disableSubmit, setDisableSubmit] = useState(false)
+    const [notification, setNotification] = useState()
+    const [loading, setLoading] = useState(false)
 
     useEffect( () => {
         try{
@@ -58,6 +60,21 @@ function App() {
             setDisableCanvas(true)
         }
     }, [numSegments, toRemove])
+
+    useEffect( () => {
+        if(loading) {
+            try {
+                let newCantor = new Cantor(numSegments, toRemove, numIter)
+                setCantor(newCantor)
+                setDisplayResults(true)
+                setLoading(false)
+            } catch(e) {
+                setNotification(e)
+                setCantor( new Cantor(numSegments, toRemove, 1) )
+                setLoading(false)
+            }
+        }
+    }, [ loading ])
 
     const inputErrors = {
         'numSegments': `Please enter a number between ${minSegments} and ${maxSegments}.`,
@@ -164,7 +181,8 @@ function App() {
             return
         }
 
-
+        setLoading(true)
+/*
         try {
             let newCantor = new Cantor(numSegments, toRemove, numIter)
             setCantor(newCantor)
@@ -173,15 +191,26 @@ function App() {
             setNotification(e)
             setCantor( new Cantor(numSegments, toRemove, 1) )
         }
+        */
     }
 
 
     const showDemo = () => {
         return(
+            <Demo
+                cantorIter = {cantor.iterations[0]}
+                isDemo={true}
+                loading={loading}
+                disableCanvas={disableCanvas}
+            />
+        )
+        /*
+        return(
             <div className={`${disableCanvas ? 'disable-item': ''}`}>
                 <Numberline intCol={cantor.iterations[0]} isDemo={true}/>
             </div>
         )
+        */
     }
 
     const showSetupButtons = () => {
@@ -288,6 +317,9 @@ function App() {
 
     const showNotification = () => {
         return(<ErrorNotification error={notification}/>)
+    }
+
+    const dummy = () => {
     }
 
     return (

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,6 @@ import Header from './components/Header'
 import ErrorNotification from './components/ErrorNotification'
 import SetupCantor from './components/SetupCantor'
 import ButtonSet from './components/ButtonSet'
-import Numberline from './components/Numberline'
 import CantorResults from './components/CantorResults'
 import Demo from './components/Demo'
 

--- a/src/components/CantorIteration.js
+++ b/src/components/CantorIteration.js
@@ -8,7 +8,8 @@ import { AiFillCaretDown, AiFillCaretRight } from 'react-icons/ai'
 import { IconContext } from 'react-icons'
 
 const CantorIteration = ({ intCol, index }) => {
-    const [showDetails, setShowDetails] = useState(false)
+    const toggleDefault = index === 0 ? true : false
+    const [showDetails, setShowDetails] = useState(toggleDefault)
 
     const toggleDetails = () => {
         setShowDetails(!showDetails)

--- a/src/components/CantorIteration.js
+++ b/src/components/CantorIteration.js
@@ -1,22 +1,48 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-//import Cantor from '../models/cantor'
+import { useState, useEffect } from 'react'
 import IntervalCollection from '../models/interval_collection'
 import Numberline from './Numberline'
 import CantorTable from './CantorTable'
+import { AiFillCaretDown, AiFillCaretRight } from 'react-icons/ai'
+import { IconContext } from 'react-icons'
 
 const CantorIteration = ({ intCol, index }) => {
+    const [showDetails, setShowDetails] = useState(false)
+
+    const toggleDetails = () => {
+        setShowDetails(!showDetails)
+    }
+
+    const displayToggle = () => {
+        return showDetails
+            ? <AiFillCaretDown/>
+            : <AiFillCaretRight/>
+    }
+
+    const cantorTable = (kind) => {
+        return (
+            kind === 'seg'
+            ? <CantorTable intervalArr={intCol.intervals} kind='segment' totLen={intCol.len}/>
+            : <CantorTable intervalArr={intCol.gaps} kind='gap' totLen={intCol.gapLen} />
+        )
+    }
+
+
     return(
-        <div className='cantor-result-iteration'>
-            <div className='cantor-result-numberline'>
-                <Numberline intCol={intCol} isDemo={false}/>
+        <IconContext.Provider value={{ color: getComputedStyle(document.body).getPropertyValue('--color-bluish') }}>
+            <div className='cantor-result-iteration'>
+                <div className='cantor-result-numberline'>
+                    <Numberline intCol={intCol} isDemo={false}/>
+                </div>
+                <div className='cantor-result-iteration-name' onClick={toggleDetails}>
+                    {displayToggle()}
+                    Iteration {index + 1}
+                </div>
+                {showDetails && cantorTable('seg')}
+                {showDetails && cantorTable('gap')}
             </div>
-            <div className='cantor-result-iteration-name'>
-                Iteration {index + 1}
-            </div>
-            <CantorTable intervalArr={intCol.intervals} kind='segment' totLen={intCol.len}/>
-            <CantorTable intervalArr={intCol.gaps} kind='gap' totLen={intCol.gapLen}/>
-        </div>
+        </IconContext.Provider>
     )
 }
 

--- a/src/components/CantorIteration.js
+++ b/src/components/CantorIteration.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import IntervalCollection from '../models/interval_collection'
 import Numberline from './Numberline'
 import CantorTable from './CantorTable'
@@ -24,8 +24,8 @@ const CantorIteration = ({ intCol, index }) => {
     const cantorTable = (kind) => {
         return (
             kind === 'seg'
-            ? <CantorTable intervalArr={intCol.intervals} kind='segment' totLen={intCol.len}/>
-            : <CantorTable intervalArr={intCol.gaps} kind='gap' totLen={intCol.gapLen} />
+                ? <CantorTable intervalArr={intCol.intervals} kind='segment' totLen={intCol.len}/>
+                : <CantorTable intervalArr={intCol.gaps} kind='gap' totLen={intCol.gapLen} />
         )
     }
 

--- a/src/components/CantorResults.js
+++ b/src/components/CantorResults.js
@@ -13,6 +13,7 @@ const CantorResults = ({ cantorSet }) => {
             <div className='cantor-results'>
                 {cantorSet.iterations.map( (iter, idx) => <CantorIteration key={idx} intCol={iter} index={idx}/>)}
             </div>
+            <hr className='horizontal-line'></hr>
         </div>
     )
 }

--- a/src/components/Demo.js
+++ b/src/components/Demo.js
@@ -1,19 +1,32 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Numberline from './Numberline'
-import Cantor from '../models/cantor'
+import IntervalCollection from '../models/interval_collection'
+import RiseLoader from 'react-spinners/RiseLoader'
 
-const Demo = ({ cantor }) => {
-    return(
-        <Numberline
-            intCol={cantor.iterations[0]}
-            isDemo={true}
-        />
+const Demo = ({ cantorIter, isDemo, disableCanvas, loading }) => {
+    return (
+        <div className='spinner-parent'>
+            <div className={ `${ loading ? '' : 'hidden'} loading-spinner`} >
+                <RiseLoader
+                    color={getComputedStyle(document.body).getPropertyValue('--color-dark-bluish')}
+                />
+            </div>
+            <div className={`${(disableCanvas || loading) ? 'disable-item': ''}`}>
+                <Numberline
+                    intCol={cantorIter}
+                    isDemo={isDemo}
+                />
+            </div>
+        </div>
     )
 }
 
 Demo.propTypes = {
-    cantor: PropTypes.instanceOf(Cantor)
+    cantorIter:     PropTypes.instanceOf(IntervalCollection),
+    isDemo:         PropTypes.bool,
+    disableCanvas:  PropTypes.bool,
+    loading:        PropTypes.bool
 }
 
 export default Demo

--- a/src/components/ErrorNotification.js
+++ b/src/components/ErrorNotification.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 const ErrorNotification = ({ error }) => {
     return (
         <div role="alert" className='notification'>
-            <pre>{error.message}</pre>
+            <pre>{error.message ? error.message : error}</pre>
         </div>
     )
 }

--- a/src/components/Numberline.js
+++ b/src/components/Numberline.js
@@ -157,7 +157,7 @@ const Numberline = ({ intCol, isDemo }) => {
                 drawFraction(ctx, interval.right, endPix, midH, size)
 
                 //label the segments numerically from left to right
-                ctx.fillStyle = '#e5b513'
+                ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--color-gold')
                 ctx.textBaseline = 'bottom'
                 ctx.fillText(idx + 1, midPoint, midH - numBottomMargin)
             }
@@ -177,7 +177,7 @@ const Numberline = ({ intCol, isDemo }) => {
                     // always use 'normal' font size for demo
                     ctx.font = `${fontDetails['labels']['normal']['fontSize']}px Verdana`
                     const segMid = start + (segmentLen * i) + segmentLen/2
-                    ctx.fillStyle = '#e5b513'
+                    ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--color-gold')
                     ctx.textBaseline = 'bottom'
                     const numBottomMargin = 15
                     ctx.fillText(i + 1, segMid, midH - numBottomMargin)
@@ -191,7 +191,7 @@ const Numberline = ({ intCol, isDemo }) => {
                 const startPix = start + (interval.left.num * segmentLen)
                 const segDrawLen = interval.len.num * segmentLen
                 const midPoint = (segDrawLen/2) + startPix
-                ctx.fillStyle = '#609ab8'
+                ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--color-gap-label-blue')
                 ctx.textBaseline = 'bottom'
                 const numBottomMargin = 15
                 ctx.fillText( getLabel(index), midPoint, midH - numBottomMargin )

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,8 @@ body {
     --color-green: #72bb53;
     --color-dark-green: #629c44;
     --color-dark-gray: #696969; /*nice*/
+    --color-gold: #e5b513;
+    --color-gap-label-blue: #609ab8;
 }
 
 a {
@@ -92,13 +94,35 @@ a {
     height: 200px;
 }
 
+.spinner-parent {
+    position: relative;
+}
+
+.loading-spinner {
+    position: absolute;
+    height: 200px;
+    width: 100%;
+    z-index: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.hidden {
+    position: absolute;
+    display: none;
+    width: 100%;
+}
+
 .disable-item {
+    z-index: auto;
     background-color: grey;
     opacity: 0.3;
     height:100%;
     width:100%;
     background-repeat:no-repeat;
 }
+
 /****************/
 
 .horizontal-line {
@@ -125,6 +149,7 @@ a {
     font-weight: 600;
     font-size: 1.2em;
 }
+
 .cantor-table-tot-len, .cantor-table-count {
     text-transform: capitalize;
     margin: 10px 0px;
@@ -146,6 +171,14 @@ a {
     grid-area: iter;
     font-size: 2em;
     font-weight: 600;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+}
+
+.cantor-result-iteration-name:hover {
+    cursor: pointer;
 }
 
 .cantor-result-segments {

--- a/src/index.css
+++ b/src/index.css
@@ -175,10 +175,31 @@ a {
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
+    position: relative;
 }
 
 .cantor-result-iteration-name:hover {
     cursor: pointer;
+    color: var(--color-bluish);
+}
+
+
+.cantor-result-iteration-name::before {
+    content: "";
+    position: absolute;
+    display: block;
+    width: 100%;
+    height: 2px;
+    bottom: 0;
+    left: 0;
+    background-color: var(--color-bluish);
+    transform: scaleX(0);
+    transition: transform 0.3s ease;
+}
+
+
+.cantor-result-iteration-name:hover::before {
+    transform: scaleX(1);
 }
 
 .cantor-result-segments {

--- a/src/index.css
+++ b/src/index.css
@@ -167,6 +167,7 @@ a {
     grid-area: nl;
 }
 
+/* https://tobiasahlin.com/blog/css-trick-animating-link-underlines/ */
 .cantor-result-iteration-name {
     grid-area: iter;
     font-size: 2em;


### PR DESCRIPTION
closes
- #59 - add spinner for loading during computation of cantor
- #63 - add caret to show/hide tables - default to closed after every iteration but the first

also
- added some underlines for the table show/hide
- added another hr to the bottom of results to mirror the top hr near buttons
- fixed hardcoded css values in drawing numberline to reference css vars